### PR TITLE
Add crab scripts, options to save provenance in postprocessing and create FJR 

### DIFF
--- a/crab/PSet.py
+++ b/crab/PSet.py
@@ -1,8 +1,11 @@
+#this fake PSET is needed for local test and for crab to figure the output filename
+#you do not need to edit it unless you want to do a local test using a different input file than
+#the one marked below
 import FWCore.ParameterSet.Config as cms
 process = cms.Process('NANO')
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring())
 process.source.fileNames = [
-	'../../NanoAOD/test/save.root'
+	'../../NanoAOD/test/lzma.root' ##you can change only this line
 ]
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
 process.output = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string('tree.root'))

--- a/crab/PSet.py
+++ b/crab/PSet.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+process = cms.Process('NANO')
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring())
+process.source.fileNames = [
+	'../../NanoAOD/test/save.root'
+]
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
+process.output = cms.OutputModule("PoolOutputModule", fileName = cms.untracked.string('tree.root'))
+process.out = cms.EndPath(process.output)
+

--- a/crab/PSet.py
+++ b/crab/PSet.py
@@ -3,7 +3,9 @@
 #the one marked below
 import FWCore.ParameterSet.Config as cms
 process = cms.Process('NANO')
-process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring())
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(),
+#	lumisToProcess=cms.untracked.VLuminosityBlockRange("254231:1-254231:24")
+)
 process.source.fileNames = [
 	'../../NanoAOD/test/lzma.root' ##you can change only this line
 ]

--- a/crab/crab_cfg.py
+++ b/crab/crab_cfg.py
@@ -1,0 +1,25 @@
+from WMCore.Configuration import Configuration
+config = Configuration()
+
+config.section_("General")
+config.General.requestName = 'NanoPost7'
+config.General.transferLogs=True
+config.section_("JobType")
+config.JobType.pluginName = 'Analysis'
+config.JobType.psetName = 'PSet.py'
+config.JobType.scriptExe = 'crab_script.sh'
+config.JobType.inputFiles = ['crab_script.py','../scripts/haddnano.py'] #hadd nano will not be needed once nano tools are in cmssw
+config.JobType.sendPythonFolder	 = True
+config.section_("Data")
+config.Data.inputDataset = '/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/arizzi-NanoTest2-507dabe3d10b654abb8ddc59357bce9a/USER'
+config.Data.inputDBS = 'global'
+config.Data.splitting = 'FileBased'
+config.Data.unitsPerJob = 2
+config.Data.totalUnits = 2
+config.Data.inputDBS='phys03'
+config.Data.outLFNDirBase = '/store/user/arizzi/NanoPost/'
+config.Data.publication = True
+config.Data.outputDatasetTag = 'NanoTestPost'
+config.section_("Site")
+config.Site.storageSite = "T2_IT_Pisa"
+

--- a/crab/crab_cfg.py
+++ b/crab/crab_cfg.py
@@ -2,7 +2,7 @@ from WMCore.Configuration import Configuration
 config = Configuration()
 
 config.section_("General")
-config.General.requestName = 'NanoPost7'
+config.General.requestName = 'NanoPost1'
 config.General.transferLogs=True
 config.section_("JobType")
 config.JobType.pluginName = 'Analysis'
@@ -13,13 +13,14 @@ config.JobType.sendPythonFolder	 = True
 config.section_("Data")
 config.Data.inputDataset = '/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/arizzi-NanoTest2-507dabe3d10b654abb8ddc59357bce9a/USER'
 config.Data.inputDBS = 'global'
-config.Data.splitting = 'FileBased'
-config.Data.unitsPerJob = 2
-config.Data.totalUnits = 2
+#config.Data.splitting = 'FileBased'
+config.Data.splitting = 'EventAwareLumiBased'
+config.Data.unitsPerJob = 100
+config.Data.totalUnits = 2000
 config.Data.inputDBS='phys03'
 config.Data.outLFNDirBase = '/store/user/arizzi/NanoPost/'
 config.Data.publication = True
 config.Data.outputDatasetTag = 'NanoTestPost'
 config.section_("Site")
-config.Site.storageSite = "T2_IT_Pisa"
+config.Site.storageSite = "T2_IT_Bari"
 

--- a/crab/crab_script.py
+++ b/crab/crab_script.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+import os
+from PhysicsTools.NanoAODTools.postprocessing.framework.postprocessor import * 
+import sys
+import re
+import PSet
+print "ARGV:",sys.argv
+JobNumber=sys.argv[1]
+crabFiles=PSet.process.source.fileNames
+print crabFiles
+firstInput = crabFiles[0]
+tested=False
+forceaaa=False
+print "--------------- using edmFileUtil to convert PFN to LFN -------------------------"
+for i in xrange(0,len(crabFiles)) :
+     if os.getenv("GLIDECLIENT_Group","") != "overflow" and  os.getenv("GLIDECLIENT_Group","") != "overflow_conservative" and not forceaaa:
+       print "Data is local"
+       pfn=os.popen("edmFileUtil -d %s"%(crabFiles[i])).read()
+       pfn=re.sub("\n","",pfn)
+       print crabFiles[i],"->",pfn
+       if not tested:
+         print "Testing file open"
+         import ROOT
+         testfile=ROOT.TFile.Open(pfn)
+         if testfile and testfile.IsOpen() :
+            print "Test OK"
+            crabFiles[i]=pfn
+            testfile.Close()
+            #tested=True
+         else :
+            print "Test open failed, forcing AAA"
+            crabFiles[i]="root://cms-xrd-global.cern.ch/"+crabFiles[i]
+            forceaaa=True
+       else :
+            crabFiles[i]=pfn
+
+
+     else:
+       print "Data is not local, using AAA/xrootd"
+       crabFiles[i]="root://cms-xrd-global.cern.ch/"+crabFiles[i]
+
+from  PhysicsTools.NanoAODTools.postprocessing.examples.mhtProducer import *
+p=PostProcessor("Output/",crabFiles,"Jet_pt>200",modules=[mht()],provenance=True)
+p.run()
+print "DONE"
+#print PSet.process.output.fileName
+os.system("ls -lR")
+os.system("./haddnano.py tree.root Output/*.root")
+#os.system("mv Output/*.root tree.root")
+os.system("ls -lR")
+
+import ROOT
+f=ROOT.TFile.Open('tree.root')
+entries=1 #f.Get('Events').GetEntries()
+
+fwkreport='''<FrameworkJobReport>
+<ReadBranches>
+</ReadBranches>
+<PerformanceReport>
+  <PerformanceSummary Metric="StorageStatistics">
+    <Metric Name="Parameter-untracked-bool-enabled" Value="true"/>
+    <Metric Name="Parameter-untracked-bool-stats" Value="true"/>
+    <Metric Name="Parameter-untracked-string-cacheHint" Value="application-only"/>
+    <Metric Name="Parameter-untracked-string-readHint" Value="auto-detect"/>
+    <Metric Name="ROOT-tfile-read-totalMegabytes" Value="0"/>
+    <Metric Name="ROOT-tfile-write-totalMegabytes" Value="0"/>
+  </PerformanceSummary>
+</PerformanceReport>
+
+<GeneratorInfo>
+</GeneratorInfo>
+
+<InputFile>
+<LFN>%s</LFN>
+<PFN></PFN>
+<Catalog></Catalog>
+<InputType>primaryFiles</InputType>
+<ModuleLabel>source</ModuleLabel>
+<GUID></GUID>
+<InputSourceClass>PoolSource</InputSourceClass>
+<EventsRead>1</EventsRead>
+<Runs>
+<Run ID="1">
+   <LumiSection ID="47805"/>
+</Run>
+
+</Runs>
+
+</InputFile>
+
+<File>
+<LFN></LFN>
+<PFN>tree.root</PFN>
+<Catalog></Catalog>
+<ModuleLabel>HEPPY</ModuleLabel>
+<GUID></GUID>
+<OutputModuleClass>PoolOutputModule</OutputModuleClass>
+<TotalEvents>%s</TotalEvents>
+<DataType></DataType>
+
+<BranchHash>dc90308e392b2fa1e0eff46acbfa24bc</BranchHash>
+
+<Runs>
+<Run ID="1">
+   <LumiSection ID="47805" NEvents="0"/>
+</Run>
+
+</Runs>
+
+</File>
+
+</FrameworkJobReport>''' % (firstInput,entries)
+
+f1=open('./FrameworkJobReport.xml', 'w+')
+f1.write(fwkreport)

--- a/crab/crab_script.py
+++ b/crab/crab_script.py
@@ -40,76 +40,8 @@ for i in xrange(0,len(crabFiles)) :
        crabFiles[i]="root://cms-xrd-global.cern.ch/"+crabFiles[i]
 
 from  PhysicsTools.NanoAODTools.postprocessing.examples.mhtProducer import *
-p=PostProcessor("Output/",crabFiles,"Jet_pt>200",modules=[mht()],provenance=True)
+p=PostProcessor(".",crabFiles,"Jet_pt>200",modules=[mht()],provenance=True,fwkJobReport=True)
 p.run()
 print "DONE"
-#print PSet.process.output.fileName
-os.system("ls -lR")
-os.system("./haddnano.py tree.root Output/*.root")
-#os.system("mv Output/*.root tree.root")
 os.system("ls -lR")
 
-import ROOT
-f=ROOT.TFile.Open('tree.root')
-entries=1 #f.Get('Events').GetEntries()
-
-fwkreport='''<FrameworkJobReport>
-<ReadBranches>
-</ReadBranches>
-<PerformanceReport>
-  <PerformanceSummary Metric="StorageStatistics">
-    <Metric Name="Parameter-untracked-bool-enabled" Value="true"/>
-    <Metric Name="Parameter-untracked-bool-stats" Value="true"/>
-    <Metric Name="Parameter-untracked-string-cacheHint" Value="application-only"/>
-    <Metric Name="Parameter-untracked-string-readHint" Value="auto-detect"/>
-    <Metric Name="ROOT-tfile-read-totalMegabytes" Value="0"/>
-    <Metric Name="ROOT-tfile-write-totalMegabytes" Value="0"/>
-  </PerformanceSummary>
-</PerformanceReport>
-
-<GeneratorInfo>
-</GeneratorInfo>
-
-<InputFile>
-<LFN>%s</LFN>
-<PFN></PFN>
-<Catalog></Catalog>
-<InputType>primaryFiles</InputType>
-<ModuleLabel>source</ModuleLabel>
-<GUID></GUID>
-<InputSourceClass>PoolSource</InputSourceClass>
-<EventsRead>1</EventsRead>
-<Runs>
-<Run ID="1">
-   <LumiSection ID="47805"/>
-</Run>
-
-</Runs>
-
-</InputFile>
-
-<File>
-<LFN></LFN>
-<PFN>tree.root</PFN>
-<Catalog></Catalog>
-<ModuleLabel>HEPPY</ModuleLabel>
-<GUID></GUID>
-<OutputModuleClass>PoolOutputModule</OutputModuleClass>
-<TotalEvents>%s</TotalEvents>
-<DataType></DataType>
-
-<BranchHash>dc90308e392b2fa1e0eff46acbfa24bc</BranchHash>
-
-<Runs>
-<Run ID="1">
-   <LumiSection ID="47805" NEvents="0"/>
-</Run>
-
-</Runs>
-
-</File>
-
-</FrameworkJobReport>''' % (firstInput,entries)
-
-f1=open('./FrameworkJobReport.xml', 'w+')
-f1.write(fwkreport)

--- a/crab/crab_script.py
+++ b/crab/crab_script.py
@@ -1,47 +1,16 @@
 #!/usr/bin/env python
 import os
 from PhysicsTools.NanoAODTools.postprocessing.framework.postprocessor import * 
-import sys
-import re
-import PSet
-print "ARGV:",sys.argv
-JobNumber=sys.argv[1]
-crabFiles=PSet.process.source.fileNames
-print crabFiles
-firstInput = crabFiles[0]
-tested=False
-forceaaa=False
-print "--------------- using edmFileUtil to convert PFN to LFN -------------------------"
-for i in xrange(0,len(crabFiles)) :
-     if os.getenv("GLIDECLIENT_Group","") != "overflow" and  os.getenv("GLIDECLIENT_Group","") != "overflow_conservative" and not forceaaa:
-       print "Data is local"
-       pfn=os.popen("edmFileUtil -d %s"%(crabFiles[i])).read()
-       pfn=re.sub("\n","",pfn)
-       print crabFiles[i],"->",pfn
-       if not tested:
-         print "Testing file open"
-         import ROOT
-         testfile=ROOT.TFile.Open(pfn)
-         if testfile and testfile.IsOpen() :
-            print "Test OK"
-            crabFiles[i]=pfn
-            testfile.Close()
-            #tested=True
-         else :
-            print "Test open failed, forcing AAA"
-            crabFiles[i]="root://cms-xrd-global.cern.ch/"+crabFiles[i]
-            forceaaa=True
-       else :
-            crabFiles[i]=pfn
 
-
-     else:
-       print "Data is not local, using AAA/xrootd"
-       crabFiles[i]="root://cms-xrd-global.cern.ch/"+crabFiles[i]
+#this takes care of converting the input files from CRAB
+from PhysicsTools.NanoAODTools.postprocessing.framework.crabhelper import inputFiles
+crabFiles=inputFiles()
+#FIXME: add lumiToProcess
 
 from  PhysicsTools.NanoAODTools.postprocessing.examples.mhtProducer import *
 p=PostProcessor(".",crabFiles,"Jet_pt>200",modules=[mht()],provenance=True,fwkJobReport=True)
 p.run()
+
 print "DONE"
 os.system("ls -lR")
 

--- a/crab/crab_script.py
+++ b/crab/crab_script.py
@@ -3,12 +3,10 @@ import os
 from PhysicsTools.NanoAODTools.postprocessing.framework.postprocessor import * 
 
 #this takes care of converting the input files from CRAB
-from PhysicsTools.NanoAODTools.postprocessing.framework.crabhelper import inputFiles
-crabFiles=inputFiles()
-#FIXME: add lumiToProcess
+from PhysicsTools.NanoAODTools.postprocessing.framework.crabhelper import inputFiles,runsAndLumis
 
 from  PhysicsTools.NanoAODTools.postprocessing.examples.mhtProducer import *
-p=PostProcessor(".",crabFiles,"Jet_pt>200",modules=[mht()],provenance=True,fwkJobReport=True)
+p=PostProcessor(".",inputFiles(),"Jet_pt>200",modules=[mht()],provenance=True,fwkJobReport=True,jsonInput=runsAndLumis())
 p.run()
 
 print "DONE"

--- a/crab/crab_script.sh
+++ b/crab/crab_script.sh
@@ -1,3 +1,10 @@
+#this is not mean to be run locally
+#
+echo Check if TTY
+if [ "`tty`" != "not a tty" ]; then
+  echo "YOU SHOULD NOT RUN THIS IN INTERACTIVE, IT DELETES YOUR LOCAL FILES"
+else
+
 ls -lR .
 echo "ENV..................................."
 env 
@@ -18,3 +25,4 @@ mv python $CMSSW_BASE/python
 
 echo Found Proxy in: $X509_USER_PROXY
 python crab_script.py $1
+fi

--- a/crab/crab_script.sh
+++ b/crab/crab_script.sh
@@ -1,0 +1,20 @@
+ls -lR .
+echo "ENV..................................."
+env 
+echo "VOMS"
+voms-proxy-info -all
+echo "CMSSW BASE, python path, pwd"
+echo $CMSSW_BASE 
+echo $PYTHON_PATH
+echo $PWD 
+rm -rf $CMSSW_BASE/lib/
+rm -rf $CMSSW_BASE/src/
+rm -rf $CMSSW_BASE/module/
+rm -rf $CMSSW_BASE/python/
+mv lib $CMSSW_BASE/lib
+mv src $CMSSW_BASE/src
+mv module $CMSSW_BASE/module
+mv python $CMSSW_BASE/python
+
+echo Found Proxy in: $X509_USER_PROXY
+python crab_script.py $1

--- a/python/postprocessing/examples/example_postproc.py
+++ b/python/postprocessing/examples/example_postproc.py
@@ -6,5 +6,5 @@ from importlib import import_module
 from PhysicsTools.NanoAODTools.postprocessing.framework.postprocessor import PostProcessor
 
 from  mhtProducer import *
-p=PostProcessor(".",["../../../../NanoAOD/test/lzma.root"],"Jet_pt>150","keep_and_drop.txt",[mht()])
+p=PostProcessor(".",["../../../../NanoAOD/test/lzma.root"],"Jet_pt>150","keep_and_drop.txt",[mht()],fwkJobReport=True,provenance=True)
 p.run()

--- a/python/postprocessing/examples/example_postproc.py
+++ b/python/postprocessing/examples/example_postproc.py
@@ -6,5 +6,5 @@ from importlib import import_module
 from PhysicsTools.NanoAODTools.postprocessing.framework.postprocessor import PostProcessor
 
 from  mhtProducer import *
-p=PostProcessor(".",["../../../../NanoAOD/test/lzma.root"],"Jet_pt>150","keep_and_drop.txt",[mht()],fwkJobReport=True,provenance=True)
+p=PostProcessor(".",["../../../../NanoAOD/test/lzma.root"],"Jet_pt>150","keep_and_drop.txt",[mht()],provenance=True)
 p.run()

--- a/python/postprocessing/framework/crabhelper.py
+++ b/python/postprocessing/framework/crabhelper.py
@@ -41,3 +41,26 @@ def inputFiles():
        print "Data is not local, using AAA/xrootd"
        crabFiles[i]="root://cms-xrd-global.cern.ch/"+crabFiles[i]
    return crabFiles
+
+def runsAndLumis():
+    if hasattr(PSet.process.source, "lumisToProcess"):
+         lumis = PSet.process.source.lumisToProcess
+	 runsAndLumis={}
+ 	 for l in lumis:
+  	     if "-" in  l:
+    		start,stop=l.split("-")
+    		rstart,lstart=start.split(":")
+    		rstop,lstop=start.split(":")
+  	     else:
+    		rstart,lstart=l.split(":")
+    		rstop,lstop=l.split(":")
+  	 if rstart!=rstop :
+              raise Exception("Cannot convert '%s' to runs and lumis json format"%l)
+         if rstart not in runsAndLumis:
+              runsAndLumis[rstart]=[]
+         runsAndLumis[rstart].append([int(lstart),int(lstop)])
+	 print "Runs and Lumis",runsAndLumis
+         return runsAndLumis 
+    return None
+
+

--- a/python/postprocessing/framework/crabhelper.py
+++ b/python/postprocessing/framework/crabhelper.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+import os
+from PhysicsTools.NanoAODTools.postprocessing.framework.postprocessor import *
+import sys
+import re
+import PSet
+
+def inputFiles():
+   print "ARGV:",sys.argv
+   JobNumber=sys.argv[1]
+   crabFiles=PSet.process.source.fileNames
+   print crabFiles
+   firstInput = crabFiles[0]
+   tested=False
+   forceaaa=False
+   print "--------------- using edmFileUtil to convert PFN to LFN -------------------------"
+   for i in xrange(0,len(crabFiles)) :
+     if os.getenv("GLIDECLIENT_Group","") != "overflow" and  os.getenv("GLIDECLIENT_Group","") != "overflow_conservative" and not forceaaa:
+       print "Data is local"
+       pfn=os.popen("edmFileUtil -d %s"%(crabFiles[i])).read()
+       pfn=re.sub("\n","",pfn)
+       print crabFiles[i],"->",pfn
+       if not tested:
+         print "Testing file open"
+         import ROOT
+         testfile=ROOT.TFile.Open(pfn)
+         if testfile and testfile.IsOpen() :
+            print "Test OK"
+            crabFiles[i]=pfn
+            testfile.Close()
+            #tested=True
+         else :
+            print "Test open failed, forcing AAA"
+            crabFiles[i]="root://cms-xrd-global.cern.ch/"+crabFiles[i]
+            forceaaa=True
+       else :
+            crabFiles[i]=pfn
+
+
+     else:
+       print "Data is not local, using AAA/xrootd"
+       crabFiles[i]="root://cms-xrd-global.cern.ch/"+crabFiles[i]
+   return crabFiles

--- a/python/postprocessing/framework/jobreport.py
+++ b/python/postprocessing/framework/jobreport.py
@@ -1,0 +1,57 @@
+import xml.etree.cElementTree as ET
+#import lxml.etree.ElementTree as ET
+class JobReport :
+       def __init__(self):
+	   self.fjr = ET.Element("FrameworkJobReport")
+           self.readbranches = ET.SubElement(self.fjr, "ReadBranches")
+           self.performancereport = ET.SubElement(self.fjr, "PerformanceReport")
+           self.performancesummary = ET.SubElement(self.performancereport, "PerformanceSummary", Metric="StorageStatistics")
+           ET.SubElement(self.performancesummary, "Metric", Name="Parameter-untracked-bool-enabled",Value="true")
+    #<Metric Name="Parameter-untracked-bool-enabled" Value="true"/>
+    #<Metric Name="Parameter-untracked-bool-stats" Value="true"/>
+    #<Metric Name="Parameter-untracked-string-cacheHint" Value="application-only"/>
+    #<Metric Name="Parameter-untracked-string-readHint" Value="auto-detect"/>
+    #<Metric Name="ROOT-tfile-read-totalMegabytes" Value="0"/>
+    #<Metric Name="ROOT-tfile-write-totalMegabytes" Value="0"/>
+
+#likely not needed
+#<GeneratorInfo>
+#</GeneratorInfo>
+
+       def addInputFile(self,filename,eventsRead=1,runsAndLumis={"1":[1]}) :
+           infile = ET.SubElement(self.fjr, "InputFile")
+	   ET.SubElement(infile,"LFN").text=filename
+	   ET.SubElement(infile,"PFN").text=""
+	   ET.SubElement(infile,"Catalog").text=""
+	   ET.SubElement(infile,"InputType").text="primaryFiles"
+	   ET.SubElement(infile,"ModuleLabel").text="source"
+	   ET.SubElement(infile,"InputSourceClass").text="PoolSource"
+	   ET.SubElement(infile,"GUID").text=""
+	   ET.SubElement(infile,"EventsRead").text="%s"%eventsRead
+	   runs=ET.SubElement(infile,"Runs")
+	   for r,ls in runsAndLumis.iteritems() :
+	   	run=ET.SubElement(runs,"Run",ID="%s"%r)
+	   	for l in ls :
+		   ET.SubElement(run,"LumiSection",ID="%s"%l)
+
+       def addOutputFile(self,filename,events=1,runsAndLumis={"1":[1]}):
+           infile = ET.SubElement(self.fjr, "File")
+           ET.SubElement(infile,"LFN").text=""
+           ET.SubElement(infile,"PFN").text=filename
+           ET.SubElement(infile,"Catalog").text=""
+           ET.SubElement(infile,"ModuleLabel").text="NANO"
+           ET.SubElement(infile,"OutputModuleClass").text="PoolOutputModule"
+           ET.SubElement(infile,"GUID").text=""
+           ET.SubElement(infile,"DataType").text=""
+           ET.SubElement(infile,"BranchHash").text="dc90308e392b2fa1e0eff46acbfa24bc"
+           ET.SubElement(infile,"TotalEvents").text="%s"%events
+           runs=ET.SubElement(infile,"Runs")
+           for r,ls in runsAndLumis.iteritems() :
+                run=ET.SubElement(runs,"Run",ID="%s"%r)
+                for l in ls :
+                   ET.SubElement(run,"LumiSection",ID="%s"%l)
+		
+       def save(self,filename="FrameworkJobReport.xml"):
+	    tree = ET.ElementTree(self.fjr)
+	    tree.write(filename) #, pretty_print=True)
+	    pass

--- a/python/postprocessing/framework/jobreport.py
+++ b/python/postprocessing/framework/jobreport.py
@@ -1,4 +1,5 @@
 import xml.etree.cElementTree as ET
+import re
 #import lxml.etree.ElementTree as ET
 class JobReport :
        def __init__(self):
@@ -7,6 +8,11 @@ class JobReport :
            self.performancereport = ET.SubElement(self.fjr, "PerformanceReport")
            self.performancesummary = ET.SubElement(self.performancereport, "PerformanceSummary", Metric="StorageStatistics")
            ET.SubElement(self.performancesummary, "Metric", Name="Parameter-untracked-bool-enabled",Value="true")
+           ET.SubElement(self.performancesummary, "Metric", Name="Parameter-untracked-bool-stats",Value="true")
+           ET.SubElement(self.performancesummary, "Metric", Name="Parameter-untracked-string-cacheHint",Value="application-only")
+           ET.SubElement(self.performancesummary, "Metric", Name="Parameter-untracked-string-readHint",Value="auto-detect")
+           ET.SubElement(self.performancesummary, "Metric", Name="ROOT-tfile-read-totalMegabytes",Value="0")
+           ET.SubElement(self.performancesummary, "Metric", Name="ROOT-tfile-write-totalMegabytes",Value="0")
     #<Metric Name="Parameter-untracked-bool-enabled" Value="true"/>
     #<Metric Name="Parameter-untracked-bool-stats" Value="true"/>
     #<Metric Name="Parameter-untracked-string-cacheHint" Value="application-only"/>
@@ -20,7 +26,7 @@ class JobReport :
 
        def addInputFile(self,filename,eventsRead=1,runsAndLumis={"1":[1]}) :
            infile = ET.SubElement(self.fjr, "InputFile")
-	   ET.SubElement(infile,"LFN").text=filename
+	   ET.SubElement(infile,"LFN").text=re.sub(r".*?(/store/.*\.root)(\?.*)?",r"\1", filename) 
 	   ET.SubElement(infile,"PFN").text=""
 	   ET.SubElement(infile,"Catalog").text=""
 	   ET.SubElement(infile,"InputType").text="primaryFiles"

--- a/python/postprocessing/framework/output.py
+++ b/python/postprocessing/framework/output.py
@@ -67,7 +67,7 @@ class FullOutput(OutputTree):
             if kn == "Events":
                 continue # this we are doing
             elif kn in ("MetaData", "ParameterSets"):
-                if provenance: self._otherTrees[tn] = inputFile.Get(kn).CopyTree('1')
+                if provenance: self._otherTrees[kn] = inputFile.Get(kn).CopyTree('1')
             elif kn in ("LuminosityBlocks", "Runs"):
                 if not jsonFilter: self._otherTrees[kn] = inputFile.Get(kn).CopyTree('1')
                 else:

--- a/python/postprocessing/framework/postprocessor.py
+++ b/python/postprocessing/framework/postprocessor.py
@@ -9,7 +9,7 @@ from PhysicsTools.NanoAODTools.postprocessing.framework.output import FriendOutp
 from PhysicsTools.NanoAODTools.postprocessing.framework.preskimming import preSkim
 
 class PostProcessor :
-    def __init__(self,outputDir,inputFiles,cut=None,branchsel=None,modules=[],compression="LZMA:9",friend=False,postfix=None,json=None,noOut=False,justcount=False):
+    def __init__(self,outputDir,inputFiles,cut=None,branchsel=None,modules=[],compression="LZMA:9",friend=False,postfix=None,json=None,noOut=False,justcount=False,provenance=False):
 	self.outputDir=outputDir
 	self.inputFiles=inputFiles
 	self.cut=cut
@@ -20,6 +20,7 @@ class PostProcessor :
 	self.noOut=noOut
 	self.friend=friend
 	self.justcount=justcount
+	self.provenance=provenance
  	self.branchsel = BranchSelection(branchsel) if branchsel else None 
     def run(self) :
     	if not self.noOut:
@@ -75,7 +76,7 @@ class PostProcessor :
 	    if self.friend:
 		outTree = FriendOutput(inFile, inTree, outFile)
 	    else:
-		outTree = FullOutput(inFile, inTree, outFile, branchSelection = self.branchsel, fullClone = fullClone, jsonFilter = jsonFilter)
+		outTree = FullOutput(inFile, inTree, outFile, branchSelection = self.branchsel, fullClone = fullClone, jsonFilter = jsonFilter,provenance=self.provenance)
 
 	    # process events, if needed
 	    if not fullClone:

--- a/python/postprocessing/framework/postprocessor.py
+++ b/python/postprocessing/framework/postprocessor.py
@@ -103,7 +103,7 @@ class PostProcessor :
 	for m in self.modules: m.endJob()
 
 	if self.haddFileName :
-		os.system("haddnano.py %s %s" %(self.haddFileName," ".join(outFileNames)))
+		os.system("./haddnano.py %s %s" %(self.haddFileName," ".join(outFileNames))) #FIXME: remove "./" once haddnano.py is distributed with cms releases
 	if self.jobReport :
 		self.jobReport.addOutputFile(self.haddFileName)
 		self.jobReport.save()

--- a/python/postprocessing/framework/postprocessor.py
+++ b/python/postprocessing/framework/postprocessor.py
@@ -11,14 +11,14 @@ from PhysicsTools.NanoAODTools.postprocessing.framework.jobreport import JobRepo
 
 class PostProcessor :
     def __init__(self,outputDir,inputFiles,cut=None,branchsel=None,modules=[],compression="LZMA:9",friend=False,postfix=None,
-		 json=None,noOut=False,justcount=False,provenance=False,haddFileName=None,fwkJobReport=False):
+		 jsonInput=None,noOut=False,justcount=False,provenance=False,haddFileName=None,fwkJobReport=False):
 	self.outputDir=outputDir
 	self.inputFiles=inputFiles
 	self.cut=cut
 	self.modules=modules
 	self.compression=compression
 	self.postfix=postfix
-	self.json=json
+	self.json=jsonInput
 	self.noOut=noOut
 	self.friend=friend
 	self.justcount=justcount


### PR DESCRIPTION
Run post processing on crab.
Support lumi-splitting and eventsAwareLumiSplitting
runsAndLumis json can now be passed as a dict rather than json file

Also introduce options to create FrameworkJobReport out of the python postprocessor (used by the crab config)