### PR TITLE
fixed bugs that caused btagSF to be evaluated to zero for some jets:

### DIFF
--- a/python/postprocessing/modules/btv/btagSFProducer.py
+++ b/python/postprocessing/modules/btv/btagSFProducer.py
@@ -31,7 +31,7 @@ class btagSFProducer(Module):
     """Calculate btagging scale factors
         algo has to be either 'csvv2' or 'cmva'
     """
-    def __init__(self, algo = 'csvv2', verbose = 0):
+    def __init__(self, algo = 'csvv2', verbose = 1):
 
         self.algo = algo.lower()
 
@@ -156,8 +156,8 @@ class btagSFProducer(Module):
             If unknown wp/syst/mtype/flavor, returns -1.0
         """
 
-        if not (pt > self.min_pt and pt < self.max_pt and abs(eta) < self.max_abs_eta):
-            return 1.
+        ##if not (pt > self.min_pt and pt < self.max_pt and abs(eta) < self.max_abs_eta):
+        ##    return 1.
 
         flavor_btv = None
         if abs(flavor) == 5:

--- a/python/postprocessing/modules/btv/btagSFProducer.py
+++ b/python/postprocessing/modules/btv/btagSFProducer.py
@@ -196,6 +196,7 @@ class btagSFProducer(Module):
         """process event, return True (go to next module) or False (fail, go to next event)"""
         jets = Collection(event, "Jet")
 
+        discr = None
         if self.algo == "csvv2":
             discr = "btagDeepB"
         elif self.algo == "cmva":

--- a/python/postprocessing/modules/btv/btagSFProducer.py
+++ b/python/postprocessing/modules/btv/btagSFProducer.py
@@ -51,7 +51,7 @@ class btagSFProducer(Module):
         self.measurement_types = None
         if self.algo == "csvv2":
             self.inputFileName = "btagSF_CSVv2_ichep2016.csv"
-            print "Loading btagSF weights for CSV (v2) algorithm from file '%s'" % os.path.join(self.inputFilePath, self.inputFileName)
+            print("Loading btagSF weights for CSV (v2) algorithm from file '%s'" % os.path.join(self.inputFilePath, self.inputFileName))
             self.measurement_types = {
                 0 : "comb",  # b
                 1 : "comb",  # c
@@ -59,7 +59,7 @@ class btagSFProducer(Module):
             }
         elif self.algo == "cmva":
             self.inputFileName = "btagSF_cMVAv2_ichep2016.csv"
-            print "Loading btagSF weights for cMVA algorithm from file '%s'" % os.path.join(self.inputFilePath, self.inputFileName)
+            print("Loading btagSF weights for cMVA algorithm from file '%s'" % os.path.join(self.inputFilePath, self.inputFileName))
             self.measurement_types = {
                 0 : "ttbar", # b
                 1 : "ttbar", # c
@@ -71,7 +71,7 @@ class btagSFProducer(Module):
         # load libraries for accessing b-tag scale factors (SFs) from conditions database
         for library in [ "libCondFormatsBTauObjects", "libCondToolsBTau" ]:
             if library not in ROOT.gSystem.GetLibraries():
-                print "Load Library '%s'" % library.replace("lib", "")
+                print("Load Library '%s'" % library.replace("lib", ""))
                 ROOT.gSystem.Load(library)
 
         # define systematic uncertainties
@@ -201,7 +201,7 @@ class btagSFProducer(Module):
         elif self.algo == "cmva":
             discr = "btagCMVA"
         else:
-            raise ValueError("ERROR: Invalid algorithm '%s'! Please choose either 'csvv2' or 'cmva'." % algo)
+            raise ValueError("ERROR: Invalid algorithm '%s'! Please choose either 'csvv2' or 'cmva'." % self.algo)
 
         for central_or_syst in self.central_and_systs:
             scale_factors = []

--- a/python/postprocessing/modules/btv/btagSFProducer.py
+++ b/python/postprocessing/modules/btv/btagSFProducer.py
@@ -44,6 +44,7 @@ class btagSFProducer(Module):
         #
         self.max_abs_eta = 2.4
         self.min_pt = 30.
+        self.max_pt = 670.
 
         # define measurement type for each flavor
         self.inputFilePath = os.environ['CMSSW_BASE'] + "/src/PhysicsTools/NanoAODTools/data/btagSF/"
@@ -155,7 +156,7 @@ class btagSFProducer(Module):
             If unknown wp/syst/mtype/flavor, returns -1.0
         """
 
-        if pt < self.min_pt or abs(eta) > self.max_abs_eta:
+        if not (pt > self.min_pt and pt < self.max_pt and abs(eta) < self.max_abs_eta):
             return 1.
 
         flavor_btv = None

--- a/python/postprocessing/modules/btv/btagSFProducer.py
+++ b/python/postprocessing/modules/btv/btagSFProducer.py
@@ -31,7 +31,7 @@ class btagSFProducer(Module):
     """Calculate btagging scale factors
         algo has to be either 'csvv2' or 'cmva'
     """
-    def __init__(self, algo = 'csvv2', verbose = 1):
+    def __init__(self, algo = 'csvv2', verbose = 0):
 
         self.algo = algo.lower()
 
@@ -156,8 +156,8 @@ class btagSFProducer(Module):
             If unknown wp/syst/mtype/flavor, returns -1.0
         """
 
-        ##if not (pt > self.min_pt and pt < self.max_pt and abs(eta) < self.max_abs_eta):
-        ##    return 1.
+        if not (pt > self.min_pt and pt < self.max_pt and abs(eta) < self.max_abs_eta):
+            return 1.
 
         flavor_btv = None
         if abs(flavor) == 5:

--- a/python/postprocessing/modules/btv/btagSFProducer.py
+++ b/python/postprocessing/modules/btv/btagSFProducer.py
@@ -2,7 +2,7 @@ import ROOT
 import os
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 
-from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection 
+from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection
 from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
 
 def is_relevant_syst_for_shape_corr(flavor_btv, syst):
@@ -23,6 +23,8 @@ def is_relevant_syst_for_shape_corr(flavor_btv, syst):
                          "up_hf", "down_hf",
                          "up_lfstats1", "down_lfstats1",
                          "up_lfstats2", "down_lfstats2" ]
+    else:
+        raise ValueError("ERROR: Undefined flavor = %i!!" % flavor_btv)
     return True
 
 class btagSFProducer(Module):
@@ -32,8 +34,16 @@ class btagSFProducer(Module):
     def __init__(self, algo = 'csvv2', verbose = 0):
 
         self.algo = algo.lower()
-        
+
         self.verbose = verbose
+
+        # CV: Return value of BTagCalibrationReader::eval_auto_bounds() is zero
+        #     in case no SF is defined for a given jet pT and eta in the btagSF.csv file !!
+        #
+        #     In the current version of the btagSF.csv files this is the case for jet pT < 30 GeV or abs(eta) > 2.4
+        #
+        self.max_abs_eta = 2.4
+        self.min_pt = 30.
 
         # define measurement type for each flavor
         self.inputFilePath = os.environ['CMSSW_BASE'] + "/src/PhysicsTools/NanoAODTools/data/btagSF/"
@@ -70,8 +80,7 @@ class btagSFProducer(Module):
         self.systs.append("down")
         self.central_and_systs = [ "central" ]
         self.central_and_systs.extend(self.systs)
-        #print "central_and_systs = ", self.central_and_systs
-        
+
         self.systs_shape_corr = []
         for syst in [ 'jes',
                       'lf', 'hf',
@@ -82,24 +91,25 @@ class btagSFProducer(Module):
             self.systs_shape_corr.append("down_%s" % syst)
         self.central_and_systs_shape_corr = [ "central" ]
         self.central_and_systs_shape_corr.extend(self.systs_shape_corr)
-        #print "central_and_systs_shape_corr = ", self.central_and_systs_shape_corr
-                             
-        self.branchNames = {}        
+
+        self.branchNames_central_and_systs = {}
         for central_or_syst in self.central_and_systs:
             if central_or_syst == "central":
-                self.branchNames[central_or_syst] = "Jet_btagSF"
+                self.branchNames_central_and_systs[central_or_syst] = "Jet_btagSF"
             else:
-                self.branchNames[central_or_syst] = "Jet_btagSF_%s" % central_or_syst
+                self.branchNames_central_and_systs[central_or_syst] = "Jet_btagSF_%s" % central_or_syst
+
+        self.branchNames_central_and_systs_shape_corr = {}
         for central_or_syst in self.central_and_systs_shape_corr:
             if central_or_syst == "central":
-                self.branchNames[central_or_syst] = "Jet_btagSF_shape"
+                self.branchNames_central_and_systs_shape_corr[central_or_syst] = "Jet_btagSF_shape"
             else:
-                self.branchNames[central_or_syst] = "Jet_btagSF_shape_%s" % central_or_syst
+                self.branchNames_central_and_systs_shape_corr[central_or_syst] = "Jet_btagSF_shape_%s" % central_or_syst
 
     def beginJob(self):
         # initialize BTagCalibrationReader
         # (cf. https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagCalibration )
-        self.calibration = ROOT.BTagCalibration(self.algo, os.path.join(self.inputFilePath, self.inputFileName))        
+        self.calibration = ROOT.BTagCalibration(self.algo, os.path.join(self.inputFilePath, self.inputFileName))
         self.readers = {}
         for wp in [ "L", "M", "T", "shape_corr" ]:
             wp_btv = { "l" : 0, "m" : 1, "t" : 2, "shape_corr" : 3 }.get(wp.lower(), None)
@@ -112,26 +122,26 @@ class btagSFProducer(Module):
             for syst in systs:
                 v_systs.push_back(syst)
             reader = ROOT.BTagCalibrationReader(wp_btv, 'central', v_systs)
-            if wp == "shape_corr":
-                reader.load(self.calibration, flavor_btv, 'iterativefit')
-            else:
-                for flavor_btv in [ 0, 1, 2 ]:                
+            for flavor_btv in [ 0, 1, 2 ]:
+                if wp == "shape_corr":
+                    reader.load(self.calibration, flavor_btv, 'iterativefit')
+                else:
                     reader.load(self.calibration, flavor_btv, self.measurement_types[flavor_btv])
             self.readers[wp_btv] = reader
 
     def endJob(self):
         pass
-    
+
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         self.out = wrappedOutputTree
         for central_or_syst in self.central_and_systs:
-            self.out.branch(self.branchNames[central_or_syst], "F", lenVar="nJet")
+            self.out.branch(self.branchNames_central_and_systs[central_or_syst], "F", lenVar="nJet")
         for central_or_syst in self.central_and_systs_shape_corr:
-            self.out.branch(self.branchNames[central_or_syst], "F", lenVar="nJet")
-        
+            self.out.branch(self.branchNames_central_and_systs_shape_corr[central_or_syst], "F", lenVar="nJet")
+
     def endFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         pass
-    
+
     def getSF(self, pt, eta, flavor, syst = 'central', wp = 'M', measurement_type = 'auto', shape_corr = False, discr = 0.):
         """Evaluate the SFs.
             Note the flavor convention: hadronFlavor is b = 5, c = 4, f = 0
@@ -145,7 +155,9 @@ class btagSFProducer(Module):
             If unknown wp/syst/mtype/flavor, returns -1.0
         """
 
-        
+        if pt < self.min_pt or abs(eta) > self.max_abs_eta:
+            return 1.
+
         flavor_btv = None
         if abs(flavor) == 5:
             flavor_btv = 0
@@ -155,7 +167,7 @@ class btagSFProducer(Module):
             flavor_btv = 2
         else:
             if self.verbose > 0:
-                print "WARNING: Unknown flavor '%s', setting b-tagging SF to -1!" % repr(flavor)
+                print("WARNING: Unknown flavor '%s', setting b-tagging SF to -1!" % repr(flavor))
             return -1.
 
         if shape_corr:
@@ -163,16 +175,11 @@ class btagSFProducer(Module):
         wp_btv = { "l" : 0, "m" : 1, "t" : 2, "shape_corr" : 3 }.get(wp.lower(), None)
         if wp_btv == None or not wp_btv in self.readers.keys():
             if self.verbose > 0:
-                print "WARNING: Unknown working point '%s', setting b-tagging SF to -1!" % wp
+                print("WARNING: Unknown working point '%s', setting b-tagging SF to -1!" % wp)
             return -1.
         reader = self.readers[wp_btv]
 
         syst = syst.lower()
-
-        if measurement_type == 'auto':
-            measurement_type = self.measurement_types[flavor_btv]
-        if shape_corr:
-            measurement_type = 'iterativefit'
 
         # evaluate SF
         sf = None
@@ -184,37 +191,41 @@ class btagSFProducer(Module):
         else:
             sf = reader.eval_auto_bounds(syst, flavor_btv, eta, pt)
         return sf
-        
+
     def analyze(self, event):
         """process event, return True (go to next module) or False (fail, go to next event)"""
         jets = Collection(event, "Jet")
 
-        # fill b-tagging SF
-        for idx, jet in enumerate(jets):
-            discr = None
-            if self.algo == "csvv2":
-                discr = jet.btagDeepB
-            elif self.algo == "cmva":
-                discr = jet.btagCMVA
-            else:
-                raise ValueError("ERROR: Invalid algorithm '%s'! Please choose either 'csvv2' or 'cmva'." % algo)
-            #print "jet #%i: pT = %1.1f, eta = %1.1f, discr = %1.3f, flavor = %i" % (idx, jet.pt, jet.eta, discr, jet.partonFlavour)
+        if self.algo == "csvv2":
+            discr = "btagDeepB"
+        elif self.algo == "cmva":
+            discr = "btagCMVA"
+        else:
+            raise ValueError("ERROR: Invalid algorithm '%s'! Please choose either 'csvv2' or 'cmva'." % algo)
+
+        for central_or_syst in self.central_and_systs:
             scale_factors = []
-            for central_or_syst in self.central_and_systs:
-                sf = self.getSF(jet.pt, jet.eta, jet.partonFlavour, central_or_syst, 'M', 'auto', False, discr)
-                #print " %s = %1.3f" % (self.branchNames[central_or_syst], sf)
+            for idx, jet in enumerate(jets):
+                sf = self.getSF(jet.pt, jet.eta, jet.partonFlavour, central_or_syst, 'M', 'auto', False, getattr(jet, discr))
+                if self.verbose > 0 and sf < 0.01:
+                    print("jet #%i: pT = %1.1f, eta = %1.1f, discr = %1.3f, flavor = %i" % (idx, jet.pt, jet.eta, getattr(jet, discr), jet.partonFlavour))
                 scale_factors.append(sf)
-            self.out.fillBranch(self.branchNames[central_or_syst], scale_factors)
+            self.out.fillBranch(self.branchNames_central_and_systs[central_or_syst], scale_factors)
+            #print(self.branchNames_central_and_systs[central_or_syst], scale_factors)
+        for central_or_syst in self.central_and_systs_shape_corr:
             scale_factors = []
-            for central_or_syst in self.central_and_systs_shape_corr:
-                sf = self.getSF(jet.pt, jet.eta, jet.partonFlavour, central_or_syst, 'shape_corr', 'auto', True, discr)
-                #print " %s = %1.3f" % (self.branchNames[central_or_syst], sf)
+            for idx, jet in enumerate(jets):
+                sf = self.getSF(jet.pt, jet.eta, jet.partonFlavour, central_or_syst, 'shape_corr', 'auto', True, getattr(jet, discr))
+                if self.verbose > 0 and sf < 0.01:
+                    print("jet #%i: pT = %1.1f, eta = %1.1f, discr = %1.3f, flavor = %i" % (idx, jet.pt, jet.eta, getattr(jet, discr), jet.partonFlavour))
                 scale_factors.append(sf)
-            self.out.fillBranch(self.branchNames[central_or_syst], scale_factors)
+            self.out.fillBranch(self.branchNames_central_and_systs_shape_corr[central_or_syst], scale_factors)
+            #print(self.branchNames_central_and_systs_shape_corr[central_or_syst], scale_factors)
+        #print('-' * 120)
 
         return True
-        
+
 # define modules using the syntax 'name = lambda : constructor' to avoid having them loaded when not needed
 
 btagSF = lambda : btagSFProducer()
-   
+


### PR DESCRIPTION
- added workaround for the fact that BTagCalibrationReader::eval_auto_bounds() returns zero
  in case jet pT > 30 or abs(eta) > 2.4
- fixed processing of btagSF for charm and bottom jets