### PR TITLE
Fix readme and use BASH_SOURCE instead of $0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You need to setup python 2.7 and a recent ROOT version first.
     git clone https://github.com/cms-nanoAOD/nanoAOD-tools.git NanoAODTools
     cd NanoAODTools
     bash standalone/env_standalone.sh build
-    bash standalone/env_standalone.sh
+    source standalone/env_standalone.sh
 
 Repeat only the last command at the beginning of every session.
 

--- a/standalone/env_standalone.sh
+++ b/standalone/env_standalone.sh
@@ -3,10 +3,10 @@
 # Please setup python 2.7 and ROOT into your environment first
 
 CWD=$PWD
-if [ ${0:0:1} == "/" ]; then
-    FULLPATH=$0
+if [ ${BASH_SOURCE[0]:0:1} == "/" ]; then
+    FULLPATH=${BASH_SOURCE[0]}
 else
-    FULLPATH=$PWD/$0
+    FULLPATH=$PWD/${BASH_SOURCE[0]}
 fi
 cd ${FULLPATH/%env_standalone.sh/}/..
 


### PR DESCRIPTION
Using `$0` as was done in the existing standalone setup script causes issues when this script is sourced within another.  Using BASH_SOURCE instead fixes this issue [1].  Also fixed a typo in the README for setting up in stand-alone mode.

[1] I think we're targeting Bash with that script give the parameter expansion `${0:0:1}` and bash 3 or more is pretty ubiquitous these days