### PR TITLE
Replacing obsolete "mht" module

### DIFF
--- a/crab/crab_script.py
+++ b/crab/crab_script.py
@@ -5,8 +5,8 @@ from PhysicsTools.NanoAODTools.postprocessing.framework.postprocessor import *
 #this takes care of converting the input files from CRAB
 from PhysicsTools.NanoAODTools.postprocessing.framework.crabhelper import inputFiles,runsAndLumis
 
-from  PhysicsTools.NanoAODTools.postprocessing.examples.mhtProducer import *
-p=PostProcessor(".",inputFiles(),"Jet_pt>200",modules=[mht()],provenance=True,fwkJobReport=True,jsonInput=runsAndLumis())
+from  PhysicsTools.NanoAODTools.postprocessing.examples.exampleModule import *
+p=PostProcessor(".",inputFiles(),"Jet_pt>200",modules=[exampleModule()],provenance=True,fwkJobReport=True,jsonInput=runsAndLumis())
 p.run()
 
 print "DONE"


### PR DESCRIPTION
The "mht" module doesn't exist anymore, replace with "exampleModule".