### PR TITLE
Fix reading JES uncertainties file

### DIFF
--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -54,7 +54,8 @@ class jetmetUncertaintiesProducer(Module):
         self.jesUncertainty = {} 
         # implementation didn't seem to work for factorized JEC, try again another way
         for jesUncertainty in self.jesUncertainties:
-            pars = ROOT.JetCorrectorParameters(os.path.join(self.jesInputFilePath, self.jesUncertaintyInputFileName),jesUncertainty)
+            jesUncertainty_label = '' if (jesUncertainty == 'Total' and len(self.jesUncertainties) == 1) else jesUncertainty
+            pars = ROOT.JetCorrectorParameters(os.path.join(self.jesInputFilePath, self.jesUncertaintyInputFileName),jesUncertainty_label)
             self.jesUncertainty[jesUncertainty] = ROOT.JetCorrectionUncertainty(pars)    
 
         self.jetSmearer.beginJob()


### PR DESCRIPTION
When trying to run jetmetUncertainties module https://github.com/cms-nanoAOD/nanoAOD-tools/blob/271cf2c755c02292e7c64cafc720eb313ed9ce3a/python/postprocessing/modules/jme/jetmetUncertainties.py#L272 the JetCorrectorParameters instance is constructed from the file name $CMSSW_BASE/src/PhysicsTools/NanoAODTools/data/jme/Summer16_23Sep2016V4_MC_Uncertainty_AK4PFchs.txt and 'Total' as the uncertainty source/label https://github.com/cms-nanoAOD/nanoAOD-tools/blob/271cf2c755c02292e7c64cafc720eb313ed9ce3a/python/postprocessing/modules/jme/jetmetUncertainties.py#L57. This fails because the input file does not contain the label name between the brackets.

The solution is to set the label string to an empty one if only single JES uncertainty source (`'Total'`) is requested.