### PR TITLE
Move PU weight producer to module

### DIFF
--- a/interface/WeightCalculatorFromHistogram.h
+++ b/interface/WeightCalculatorFromHistogram.h
@@ -1,0 +1,34 @@
+#ifndef PhysicsTools_NanoAODTools_WeightCalculatorFromHistogram_h
+#define PhysicsTools_NanoAODTools_WeightCalculatorFromHistogram_h
+
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <algorithm>
+#include <TH1.h>
+
+class WeightCalculatorFromHistogram {
+ public:
+  WeightCalculatorFromHistogram() {}
+  // get the weight from the bin content of the passed histogram
+  WeightCalculatorFromHistogram(TH1 *histogram, bool verbose=false) : histogram_(histogram), verbose_(verbose) {}
+  // get the weight from the bin content of the ratio hist/targethist
+  WeightCalculatorFromHistogram(TH1 *hist, TH1* targethist, bool norm=true, bool fixLargeWeights=true, bool verbose=false);
+  ~WeightCalculatorFromHistogram() {}
+  
+  float getWeight(float x, float y=0) const;
+  float getWeightErr(float x, float y=0) const;
+  
+ private:
+  std::vector<float> loadVals(TH1 *hist, bool norm=true);
+  TH1* ratio(TH1 *hist, TH1* targethist, bool fixLargeWgts);
+  void fixLargeWeights(std::vector<float> &weights, float maxshift=0.0025,float hardmax=3);
+  float checkIntegral(std::vector<float> wgt1, std::vector<float> wgt2);
+
+  TH1* histogram_;
+  std::vector<float> refvals_,targetvals_;
+  bool verbose_;
+  bool norm_;
+};
+
+#endif

--- a/python/postprocessing/modules/common/puWeightProducer.py
+++ b/python/postprocessing/modules/common/puWeightProducer.py
@@ -23,9 +23,19 @@ class puWeightProducer(Module):
         self.norm = norm
         self.verbose = verbose
         self.nvtxVar = nvtx_var
-        if "/WeightCalculatorFromHistogram_cc.so" not in ROOT.gSystem.GetLibraries():
-            print "Load C++ Worker"
-            ROOT.gROOT.ProcessLine(".L %s/python/PhysicsTools/NanoAODTools/postprocessing/helpers/WeightCalculatorFromHistogram.cc++" % os.environ['CMSSW_BASE'])
+       
+        #Try to load module via python dictionaries
+        try:
+            ROOT.gSystem.Load("libPhysicsToolsNanoAODTools")
+            dummy = ROOT.WeightCalculatorFromHistogram
+        #Load it via ROOT ACLIC. NB: this creates the object file in the CMSSW directory,
+        #causing problems if many jobs are working from the same CMSSW directory
+        except Exception as e:
+            print "Could not load module via python, trying via ROOT", e
+            if "/WeightCalculatorFromHistogram_cc.so" not in ROOT.gSystem.GetLibraries():
+                print "Load C++ Worker"
+                ROOT.gROOT.ProcessLine(".L %s/src/PhysicsTools/NanoAODTools/src/WeightCalculatorFromHistogram.cc++" % os.environ['CMSSW_BASE'])
+            dummy = ROOT.WeightCalculatorFromHistogram
     def loadHisto(self,filename,hname):
         tf = ROOT.TFile.Open(filename)
         hist = tf.Get(hname)

--- a/src/WeightCalculatorFromHistogram.cc
+++ b/src/WeightCalculatorFromHistogram.cc
@@ -1,35 +1,4 @@
-#ifndef PhysicsTools_NanoAODTools_WeightCalculatorFromHistogram_h
-#define PhysicsTools_NanoAODTools_WeightCalculatorFromHistogram_h
-
-#include <iostream>
-#include <iomanip>
-#include <vector>
-#include <algorithm>
-#include <TH1.h>
-
-class WeightCalculatorFromHistogram {
- public:
-  WeightCalculatorFromHistogram() {}
-  // get the weight from the bin content of the passed histogram
-  WeightCalculatorFromHistogram(TH1 *histogram, bool verbose=false) : histogram_(histogram), verbose_(verbose) {}
-  // get the weight from the bin content of the ratio hist/targethist
-  WeightCalculatorFromHistogram(TH1 *hist, TH1* targethist, bool norm=true, bool fixLargeWeights=true, bool verbose=false);
-  ~WeightCalculatorFromHistogram() {}
-  
-  float getWeight(float x, float y=0) const;
-  float getWeightErr(float x, float y=0) const;
-  
- private:
-  std::vector<float> loadVals(TH1 *hist, bool norm=true);
-  TH1* ratio(TH1 *hist, TH1* targethist, bool fixLargeWgts);
-  void fixLargeWeights(std::vector<float> &weights, float maxshift=0.0025,float hardmax=3);
-  float checkIntegral(std::vector<float> wgt1, std::vector<float> wgt2);
-
-  TH1* histogram_;
-  std::vector<float> refvals_,targetvals_;
-  bool verbose_;
-  bool norm_;
-};
+#include "PhysicsTools/NanoAODTools/interface/WeightCalculatorFromHistogram.h"
 
 WeightCalculatorFromHistogram::WeightCalculatorFromHistogram(TH1 *hist, TH1* targethist, bool norm, bool fixLargeWeights, bool verbose) {
   norm_ = norm;
@@ -142,5 +111,3 @@ void WeightCalculatorFromHistogram::fixLargeWeights(std::vector<float> &weights,
   float normshift = checkIntegral(cropped,weights);
   for(int i=0; i<(int)weights.size(); ++i) weights[i] = cropped[i]*(1-normshift);
 }
-
-#endif

--- a/src/classes.h
+++ b/src/classes.h
@@ -1,7 +1,9 @@
 #include "PhysicsTools/NanoAODTools/interface/PyJetResolutionWrapper.h"
 #include "PhysicsTools/NanoAODTools/interface/PyJetResolutionScaleFactorWrapper.h"
 #include "PhysicsTools/NanoAODTools/interface/PyJetParametersWrapper.h"
+#include "PhysicsTools/NanoAODTools/interface/WeightCalculatorFromHistogram.h"
 
 PyJetResolutionWrapper jetRes;
 PyJetResolutionScaleFactorWrapper jetResScaleFactor;
 PyJetParametersWrapper jetParams;
+WeightCalculatorFromHistogram wcalc;

--- a/src/classes_def.xml
+++ b/src/classes_def.xml
@@ -3,5 +3,6 @@
   <class name="PyJetResolutionWrapper"/>
   <class name="PyJetResolutionScaleFactorWrapper"/>
   <class name="PyJetParametersWrapper"/>
+  <class name="WeightCalculatorFromHistogram"/>
 </selection>
 </lcgdict>


### PR DESCRIPTION
Moved PU weight producer to separate module, as ACLIC causes problems when running multiple jobs from the same working directory by overwriting/cleaning the temporary object files. Maybe there is a way to set the ACLIC compilation directory, but this seems cleaner.