### PR TITLE
improving speed of btag scale factor retrieval

### DIFF
--- a/python/postprocessing/modules/btv/btagSFProducer.py
+++ b/python/postprocessing/modules/btv/btagSFProducer.py
@@ -107,7 +107,7 @@ class btagSFProducer(Module):
                 raise ValueError("ERROR: Algorithm '%s' not supported for era = '%s'! Please choose among { %s }." % (self.algo, self.era, supported_algos))
         else:
             raise ValueError("ERROR: Algorithm '%s' not supported for era = '%s'! Please choose among { %s }." % (self.algo, self.era, supported_algos))
-        
+
         algoLabel = None
         if self.algo == "csvv2":
             algoLabel = "CSV (v2)"
@@ -162,7 +162,7 @@ class btagSFProducer(Module):
         # (cf. https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagCalibration )
         self.calibration = ROOT.BTagCalibration(self.algo, os.path.join(self.inputFilePath, self.inputFileName))
         self.readers = {}
-        for wp in self.supported_wp: 
+        for wp in self.supported_wp:
             wp_btv = { "l" : 0, "m" : 1, "t" : 2, "shape_corr" : 3 }.get(wp.lower(), None)
             syts = None
             if wp_btv in [ 0, 1, 2 ]:
@@ -193,25 +193,26 @@ class btagSFProducer(Module):
     def endFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         pass
 
-    def getSF(self, pt, eta, flavor, syst = 'central', wp = 'M', measurement_type = 'auto', shape_corr = False, discr = 0.):
-        """Evaluate the SFs.
-            Note the flavor convention: hadronFlavor is b = 5, c = 4, f = 0
-            Convert them to the btagging group convention of 0 ,1, 2
-
-            Same for working points: input is 'L', 'M', 'T'
-            Convert to 0, 1, 2
-
-            Automatically checks if values are in allowed range
-
-            If unknown wp/syst/mtype/flavor, returns -1.0
+    def getReader(self, wp, shape_corr = False):
         """
+            Get btag scale factor reader.
+            Convert working points: input is 'L', 'M', 'T', 'shape_corr' to 0, 1, 2, 3
+        """
+        if shape_corr:
+            wp = "shape_corr"
+        wp_btv = { "l" : 0, "m" : 1, "t" : 2, "shape_corr" : 3 }.get(wp.lower(), None)
+        if wp_btv == None or not wp_btv in self.readers.keys():
+            if self.verbose > 0:
+                print("WARNING: Unknown working point '%s', setting b-tagging SF to -1!" % wp)
+            return -1.
+        return self.readers[wp_btv]
 
-        epsilon = 1.e-3
-        if eta <= -self.max_abs_eta:
-            eta = -self.max_abs_eta + epsilon
-        if eta >= +self.max_abs_eta:
-            eta = +self.max_abs_eta - epsilon
-
+    def getFlavorBTV(self, flavor):
+        '''
+            Maps hadronFlavor to BTV flavor:
+            Note the flavor convention: hadronFlavor is b = 5, c = 4, f = 0
+            Convert them to the btagging group convention of 0, 1, 2
+        '''
         flavor_btv = None
         if abs(flavor) == 5:
             flavor_btv = 0
@@ -223,28 +224,32 @@ class btagSFProducer(Module):
             if self.verbose > 0:
                 print("WARNING: Unknown flavor '%s', setting b-tagging SF to -1!" % repr(flavor))
             return -1.
+        return flavor_btv
 
-        if shape_corr:
-            wp = "shape_corr"
-        wp_btv = { "l" : 0, "m" : 1, "t" : 2, "shape_corr" : 3 }.get(wp.lower(), None)
-        if wp_btv == None or not wp_btv in self.readers.keys():
-            if self.verbose > 0:
-                print("WARNING: Unknown working point '%s', setting b-tagging SF to -1!" % wp)
-            return -1.
-        reader = self.readers[wp_btv]
-
-        syst = syst.lower()
-
-        # evaluate SF
-        sf = None
-        if shape_corr:
-            if is_relevant_syst_for_shape_corr(flavor_btv, syst):
-                sf = reader.eval_auto_bounds(syst, flavor_btv, eta, pt, discr)
+    def getSFs(self, jet_data, syst, reader,  measurement_type = 'auto', shape_corr = False):
+        for idx, (pt, eta, flavor_btv, discr) in enumerate(jet_data):
+            epsilon = 1.e-3
+            max_abs_eta = self.max_abs_eta
+            if eta <= -max_abs_eta:
+                eta = -max_abs_eta + epsilon
+            if eta >= +max_abs_eta:
+                eta = +max_abs_eta - epsilon
+            # evaluate SF
+            sf = None
+            if shape_corr:
+                if is_relevant_syst_for_shape_corr(flavor_btv, syst):
+                    sf = reader.eval_auto_bounds(syst, flavor_btv, eta, pt, discr)
+                else:
+                    sf = reader.eval_auto_bounds('central', flavor_btv, eta, pt, discr)
             else:
-                sf = reader.eval_auto_bounds('central', flavor_btv, eta, pt, discr)
-        else:
-            sf = reader.eval_auto_bounds(syst, flavor_btv, eta, pt)
-        return sf
+                sf = reader.eval_auto_bounds(syst, flavor_btv, eta, pt)
+            # check if SF is OK
+            if sf < 0.01:
+                if self.verbose > 0:
+                    print("jet #%i: pT = %1.1f, eta = %1.1f, discr = %1.3f, flavor = %i" % (idx, jet_pt, jet_eta, jet_discr, jet_partonFlavour))
+                sf = 1.
+            yield sf
+
 
     def analyze(self, event):
         """process event, return True (go to next module) or False (fail, go to next event)"""
@@ -260,25 +265,17 @@ class btagSFProducer(Module):
         else:
             raise ValueError("ERROR: Invalid algorithm '%s'! Please choose either 'csvv2' or 'cmva'." % self.algo)
 
+        preloaded_jets = [(jet.pt, jet.eta, self.getFlavorBTV(jet.partonFlavour), getattr(jet, discr)) for jet in jets]
+        reader = self.getReader('M', False)
         for central_or_syst in self.central_and_systs:
-            scale_factors = []
-            for idx, jet in enumerate(jets):
-                sf = self.getSF(jet.pt, jet.eta, jet.partonFlavour, central_or_syst, 'M', 'auto', False, getattr(jet, discr))
-                if sf < 0.01:
-                    if self.verbose > 0:
-                        print("jet #%i: pT = %1.1f, eta = %1.1f, discr = %1.3f, flavor = %i" % (idx, jet.pt, jet.eta, getattr(jet, discr), jet.partonFlavour))
-                    sf = 1.
-                scale_factors.append(sf)
+            central_or_syst = central_or_syst.lower()
+            scale_factors = list(self.getSFs(preloaded_jets, central_or_syst, reader, 'auto', False))
             self.out.fillBranch(self.branchNames_central_and_systs[central_or_syst], scale_factors)
+        # shape corrections
+        reader = self.getReader('shape_corr', True)
         for central_or_syst in self.central_and_systs_shape_corr:
-            scale_factors = []
-            for idx, jet in enumerate(jets):
-                sf = self.getSF(jet.pt, jet.eta, jet.partonFlavour, central_or_syst, 'shape_corr', 'auto', True, getattr(jet, discr))
-                if sf < 0.01:
-                    if self.verbose > 0:
-                        print("jet #%i: pT = %1.1f, eta = %1.1f, discr = %1.3f, flavor = %i" % (idx, jet.pt, jet.eta, getattr(jet, discr), jet.partonFlavour))
-                    sf = 1.
-                scale_factors.append(sf)
+            central_or_syst = central_or_syst.lower()
+            scale_factors = list(self.getSFs(preloaded_jets, central_or_syst, reader, 'auto', True))
             self.out.fillBranch(self.branchNames_central_and_systs_shape_corr[central_or_syst], scale_factors)
 
         return True
@@ -287,4 +284,3 @@ class btagSFProducer(Module):
 
 btagSF2016 = lambda : btagSFProducer("2016")
 btagSF2017 = lambda : btagSFProducer("2017")
-

--- a/python/postprocessing/modules/btv/btagSFProducer.py
+++ b/python/postprocessing/modules/btv/btagSFProducer.py
@@ -203,8 +203,8 @@ class btagSFProducer(Module):
         wp_btv = { "l" : 0, "m" : 1, "t" : 2, "shape_corr" : 3 }.get(wp.lower(), None)
         if wp_btv == None or not wp_btv in self.readers.keys():
             if self.verbose > 0:
-                print("WARNING: Unknown working point '%s', setting b-tagging SF to -1!" % wp)
-            return -1.
+                print("WARNING: Unknown working point '%s', setting b-tagging SF reader to None!" % wp)
+            return None
         return self.readers[wp_btv]
 
     def getFlavorBTV(self, flavor):
@@ -227,6 +227,12 @@ class btagSFProducer(Module):
         return flavor_btv
 
     def getSFs(self, jet_data, syst, reader,  measurement_type = 'auto', shape_corr = False):
+        if reader is None:
+            if self.verbose > 0:
+                print("WARNING: Reader not available, setting b-tagging SF to -1!")
+            for i in range(len(jet_data)):
+                yield 1
+            raise StopIteration
         for idx, (pt, eta, flavor_btv, discr) in enumerate(jet_data):
             epsilon = 1.e-3
             max_abs_eta = self.max_abs_eta


### PR DESCRIPTION
# Summary
Dear all,

This PR improves the performance of the btag scale factor producer, `python/postprocessing/modules/btv/btagSFProducer.py`, by 40% (wall time).


# The issue this PR solves
A colleague of mine, @shane-breeze, observed that computing the btag scale factor does take a lot of time:
```
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    43354   31.869    0.001  140.315    0.003 btagSFProducer.py:249(analyze)
  7991874   63.137    0.000   76.069    0.000 btagSFProducer.py:196(getSF)
```

For our test sample this resulted in a total of
```
126005017 function calls (122184427 primitive calls) in 191.403 seconds
```

Looking at the code, we've found some improvement possibilities, the easiest ones are contained in this PR.

With the changes in place, the new profiling information is
```
53533045 function calls (49712455 primitive calls) in 116.827 seconds
    43354    9.206    0.000   66.927    0.002 btagSFProducer.py:284(analyze)
  8945662   34.541    0.000   37.679    0.000 btagSFProducer.py:229(getSFs)
```
The number correspond to a speedup of 40% and a reduction in function calls of 58% (calls are expensive after all.


# Implementation details
The implementation was done in several steps after each one the results were compared.
For simplicity, let's define `M = self.central_and_systs * njets + self.central_and_systs_shape_corr * njets` and `N_S = self.central_and_systs + self.central_and_systs_shape_corr`

## jet access
Previously jet variables were loaded `M` times per event. Now they are loaded once per event:
```
preloaded_jets = [(jet.pt, jet.eta, jet.partonFlavour, getattr(jet, discr)) for jet in jets]
```
This change alone bring gains of 16%.

## btag SF reader access
Previously, the btag SF reader was loaded M times per event. However, looking at the code this can be reduced to 2 times per event. Since the working points look static across events, it might be even worth moving the definitions into `beginJob`.

## other small things
 - moved `syst.lower()` outside `getSF` (`M` calls &rarr; `N_S` calls)
 - moved `flavor_btv` conversion outside `getSF` ( `M` calls &rarr; `njets` calls)

I've also moved the jet loop into the new `getSFs` function for readability.