### PR TITLE
enable shape corr for btag SF v2

### DIFF
--- a/python/postprocessing/modules/btv/btagSFProducer.py
+++ b/python/postprocessing/modules/btv/btagSFProducer.py
@@ -66,7 +66,7 @@ class btagSFProducer(Module):
                         1 : "comb",  # c
                         2 : "incl"   # light
                     },
-                    'supported_wp' : [ "L", "M", "T" ] # CV: shape corrections ('iterativefit' method) not supported for 2017 ReReco data and RunIIFall17 MC yet
+                    'supported_wp' : [ "L", "M", "T", "shape_corr"]
                 }
             },
             'deepcsv' : {
@@ -77,7 +77,7 @@ class btagSFProducer(Module):
                         1 : "comb",  # c
                         2 : "incl"   # light
                     },
-                    'supported_wp' : [ "L", "M", "T" ] # CV: shape corrections ('iterativefit' method) not supported for 2017 ReReco data and RunIIFall17 MC yet
+                    'supported_wp' : [ "L", "M", "T", "shape_corr"]
                 }
             },
             'cmva' : {
@@ -252,7 +252,7 @@ class btagSFProducer(Module):
             # check if SF is OK
             if sf < 0.01:
                 if self.verbose > 0:
-                    print("jet #%i: pT = %1.1f, eta = %1.1f, discr = %1.3f, flavor = %i" % (idx, jet_pt, jet_eta, jet_discr, jet_partonFlavour))
+                    print("jet #%i: pT = %1.1f, eta = %1.1f, discr = %1.3f, flavor = %i" % (idx, pt, eta, discr, flavor_btv))
                 sf = 1.
             yield sf
 


### PR DESCRIPTION
In V2 of the btag scale factors, the shape corrections (iterativefit) are present:

~~~
$ grep iterativefit data/btagSF/CSVv2_94XSF_V2_B_F.csv | wc -l
1668
~~~

so we can now compute them:

~~~
root [1] Friends->Scan("Jet_btagSF_shape:Jet_btagSF_shape_down_lf")
***********************************************
*    Row   * Instance * Jet_btagS * Jet_btagS *
***********************************************
*        0 *        0 * 1.0267343 * 1.0023125 *
*        0 *        1 * 0.9355568 * 0.9355568 *
*        0 *        2 * 1.5425299 * 1.5425299 *
*        0 *        3 * 0.9145733 * 0.8872598 *
*        0 *        4 * 1.0338901 * 0.9968101 *
*        0 *        5 * 1.0507129 * 1.0053309 *
*        0 *        6 * 0.9969844 * 0.9969844 *
*        0 *        7 * 0.9994378 * 0.9994378 *
*        0 *        8 * 0.9424377 * 0.9424377 *
~~~

Also fixed a broken verbose print.