### PR TITLE
Use hadronFlavour instead of partonFlavour in btagSFProducer

### DIFF
--- a/python/postprocessing/modules/btv/btagSFProducer.py
+++ b/python/postprocessing/modules/btv/btagSFProducer.py
@@ -271,7 +271,7 @@ class btagSFProducer(Module):
         else:
             raise ValueError("ERROR: Invalid algorithm '%s'! Please choose either 'csvv2' or 'cmva'." % self.algo)
 
-        preloaded_jets = [(jet.pt, jet.eta, self.getFlavorBTV(jet.partonFlavour), getattr(jet, discr)) for jet in jets]
+        preloaded_jets = [(jet.pt, jet.eta, self.getFlavorBTV(jet.hadronFlavour), getattr(jet, discr)) for jet in jets]
         reader = self.getReader('M', False)
         for central_or_syst in self.central_and_systs:
             central_or_syst = central_or_syst.lower()


### PR DESCRIPTION
From [BTagShapeCalibration Twiki](https://twiki.cern.ch/twiki/bin/view/CMS/BTagShapeCalibration?rev=19#Brief_description_of_the_Tag_and):

> Apply the scale factor based on the jet flavor (pfJet->hadronFlavour())

In CMSSW nanoAOD fork, the inclusive event-level b-tagging weight is also computed based on hadronFlavour of jets ([link](https://github.com/cms-nanoAOD/cmssw/blob/a348544b0d03cbf135953ce23c27ea2b4723327c/PhysicsTools/NanoAOD/plugins/BTagSFProducer.cc#L197)).