### PR TITLE
Nominal correction factors in jetmetUncertainties

### DIFF
--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -117,6 +117,8 @@ class jetmetUncertaintiesProducer(Module):
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         self.out = wrappedOutputTree
         self.out.branch("%s_pt_nom" % self.jetBranchName, "F", lenVar=self.lenVar)
+        self.out.branch("%s_corr_JEC" % self.jetBranchName, "F", lenVar=self.lenVar)
+        self.out.branch("%s_corr_JER" % self.jetBranchName, "F", lenVar=self.lenVar)
         self.out.branch("%s_mass_nom" % self.jetBranchName, "F", lenVar=self.lenVar)
         if self.doGroomed:
             self.out.branch("%s_msoftdrop_nom" % self.jetBranchName, "F", lenVar=self.lenVar)
@@ -166,6 +168,8 @@ class jetmetUncertaintiesProducer(Module):
             
 
         jets_pt_nom = []
+        jets_corr_JEC = []
+        jets_corr_JER = []
         jets_pt_jerUp   = []
         jets_pt_jerDown = []
         jets_pt_jesUp   = {}
@@ -235,9 +239,13 @@ class jetmetUncertaintiesProducer(Module):
             ( jet_pt_jerNomVal, jet_pt_jerUpVal, jet_pt_jerDownVal ) = self.jetSmearer.getSmearValsPt(jet, genJet, rho)
 	    
 	    jet_pt=jet.pt
+            jet_rawpt = jet.pt * (1 - jet.rawFactor)
 	    if self.redoJEC :
 		jet_pt = self.jetReCalibrator.correct(jet,rho)
+            jets_corr_JEC.append(jet_pt/jet_rawpt)
+            jets_corr_JER.append(jet_pt_jerNomVal)
             jet_pt_nom           = jet_pt_jerNomVal *jet_pt
+            
             if jet_pt_nom < 0.0:
                 jet_pt_nom *= -1.0
             jet_pt_jerUp         = jet_pt_jerUpVal  *jet_pt
@@ -357,6 +365,8 @@ class jetmetUncertaintiesProducer(Module):
 
             
         self.out.fillBranch("%s_pt_nom" % self.jetBranchName, jets_pt_nom)
+        self.out.fillBranch("%s_corr_JEC" % self.jetBranchName, jets_corr_JEC)
+        self.out.fillBranch("%s_corr_JER" % self.jetBranchName, jets_corr_JER)
         self.out.fillBranch("%s_pt_jerUp" % self.jetBranchName, jets_pt_jerUp)
         self.out.fillBranch("%s_pt_jerDown" % self.jetBranchName, jets_pt_jerDown)
         self.out.fillBranch("%s_mass_nom" % self.jetBranchName, jets_mass_nom)

--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -239,13 +239,17 @@ class jetmetUncertaintiesProducer(Module):
             ( jet_pt_jerNomVal, jet_pt_jerUpVal, jet_pt_jerDownVal ) = self.jetSmearer.getSmearValsPt(jet, genJet, rho)
 	    
 	    jet_pt=jet.pt
-            jet_rawpt = jet.pt * (1 - jet.rawFactor)
+            if hasattr(jet, "rawFactor"):
+                jet_rawpt = jet.pt * (1 - jet.rawFactor)
+            else:
+                jet_rawpt = -1.0 * jet.pt #If factor not present factor will be saved as -1
+            
 	    if self.redoJEC :
 		jet_pt = self.jetReCalibrator.correct(jet,rho)
             jets_corr_JEC.append(jet_pt/jet_rawpt)
             jets_corr_JER.append(jet_pt_jerNomVal)
-            jet_pt_nom           = jet_pt_jerNomVal *jet_pt
             
+            jet_pt_nom           = jet_pt_jerNomVal *jet_pt
             if jet_pt_nom < 0.0:
                 jet_pt_nom *= -1.0
             jet_pt_jerUp         = jet_pt_jerUpVal  *jet_pt


### PR DESCRIPTION
This PR adds branches for the nominal correction factors (JEC and JER) applied within the jetmetUncertainties post processing module. This is necessary to recalculate the uncorrected pt after post processing. W/o this change it is not possible to do this if a new JEC is applied in module.

**New Branches:**
- Jet_corr_JEC *(is equal to 1/(1-rawFactor) if no new JEC is applied in module)*
- Jet_corr_JER

Defined so that: Jet_pt_nom = Jet_pt_raw * Jet_corr_JEC * Jet_corr_JER