### PR TITLE
Working readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Here is a summary of its features:
 * the `-J`,`--json` option is used to pass the name of a JSON file that will be used to select events. It cannot be used in friend mode.
 * if run with the `--full` option (default), the output will be a full nanoAOD file. If run with the `--friend` option, instead, the output will be a friend tree that can be attached to the input tree. In the latter case, it is not possible to apply any kind of event selection, as the number of entries in the parent and friend tree must be the same.
 * the `-b`,`--branch-selection` option is used to pass the name of a file containing directives to keep or drop branches from the output tree. The file should contain one directive among `keep`/`drop` (wildcards allowed as in TTree::SetBranchStatus) or `keepmatch`/`dropmatch` (python regexp matching the branch name) per line, as shown in the [this](python/postprocessing/examples/keep_and_drop.txt) example file.
+  * `--bi` and `--bo` allows to specify the keep/drop file separately for input and output trees.  
 * the `--justcount` option will cause the script to printout the number of selected events, without actually writing the output file.
 
 Please run with `--help` for a complete list of options.
@@ -67,3 +68,15 @@ The event interface, defined in `PhysicsTools.NanoAODTools.postprocessing.framew
 and this will access the elements of the `Electron_someVar`, `Electron_pt` branch arrays. Event variables can be accessed simply by `event.someVar`, for instance `event.rho`.
 
 The output branches should be filled calling the `fillBranch(branchname, value)` method of `wrappedOutputTree`. `value` should be the desired value for single-value branches, an iterable with the correct length for array branches. It is not necessary to fill the `lenVar` branch explicitly, as this is done automatically using the length of the passed iterable.
+
+## Keep/drop branches
+See the effect of keep/drop instructions by running:
+```
+python scripts/nano_postproc.py outDir /eos/user/a/andrey/f.root -I PhysicsTools.NanoAODTools.postprocessing.examples.exampleModule exampleModule -s _exaModu_keepdrop --bi scripts/keep_and_drop_input.txt --bo scripts/keep_and_drop_output.txt
+```
+comparing to:
+```
+python scripts/nano_postproc.py outDir /eos/user/a/andrey/f.root -I PhysicsTools.NanoAODTools.postprocessing.examples.exampleModule exampleModule -s _exaModu
+```
+The output branch created by exampleModule produces the same result in both cases. But thefirst one drops all other branches when creating output tree. It also runs faster.
+

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ The output branches should be filled calling the `fillBranch(branchname, value)`
 Now, let's have a look at another example, `python/postprocessing/examples/mhtjuProducerCpp.py`, [file](python/postprocessing/examples/mhtjuProducerCpp.py). Similarly, it should be imported using the following syntax:
 
 ```
-python scripts/nano_postproc.py -I PhysicsTools.NanoAODTools.postprocessing.examples.mhtjuProducerCpp mhtju
+python scripts/nano_postproc.py outDir /eos/cms/store/user/andrey/f.root -I PhysicsTools.NanoAODTools.postprocessing.examples.mhtjuProducerCpp mhtju
 ```
-This module has the same structure of its producer as `exampleProducer`. However, in addition it utilizes a C++ code to calculate the mht variable, `src/mhtjuProducerCppWorker.cc`. This code is loaded in the `__init__` method of the producer.
+This module has the same structure of its producer as `exampleProducer`, but in addition it utilizes a C++ code to calculate the mht variable, `src/mhtjuProducerCppWorker.cc`. This code is loaded in the `__init__` method of the producer.
 
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Please never commit neither the build directory, nor the empty init.py files cre
 
     cd $CMSSW_BASE/src
     git clone https://github.com/cms-nanoAOD/nanoAOD-tools.git PhysicsTools/NanoAODTools
+    cd PhysicsTools/NanoAODTools
+    cmsenv
+    scram b
 
 ## General instructions to run the post-processing step
 
@@ -42,22 +45,28 @@ Please run with `--help` for a complete list of options.
 
 It is possible to import modules that will be run on each entry passing the event selection, and can be used to calculate new variables that will be included in the output tree (both in friend and full mode) or to apply event filter decisions.
 
-We will use `python/postprocessing/examples/mhtProducer.py` as an example.
+We will use `python/postprocessing/examples/exampleModule.py` as an example. The module definition [file](python/postprocessing/examples/exampleModule.py), containing a simple constructor
 
-The module definition [file](python/postprocessing/examples/mhtProducer.py), containing the constructor:
-
-    mht = lambda : mhtProducer( lambda j : j.pt > 40, 
-                                lambda mu : mu.pt > 20 and mu.miniPFIso_all/mu.pt < 0.2,
-                                lambda el : el.pt > 20 and el.miniPFIso_all/el.pt < 0.2 ) 
+   exampleModuleConstr = lambda : exampleProducer(jetSelection= lambda j : j.pt > 30)
 
 should be imported using the following syntax:
 
-`python scripts/nano_postproc.py -I PhysicsTools.NanoAODTools.postprocessing.examples.mhtProducer mht`
+```
+python scripts/nano_postproc.py outDir /eos/cms/store/user/andrey/f.root -I PhysicsTools.NanoAODTools.postprocessing.examples.exampleModule exampleModuleConstr
+```
 
-Let us now examine the structure of the `mhtProducer` module class. All modules must inherit from `PhysicsTools.NanoAODTools.postprocessing.framework.eventloop.Module`.
+Let us now examine the structure of the `exampleProducer` module class. All modules must inherit from `PhysicsTools.NanoAODTools.postprocessing.framework.eventloop.Module`.
 * the `__init__` constructor function should be used to set the module options.
 * the `beginFile` function should create the branches that you want to add to the output file, calling the `branch(branchname, typecode, lenVar)` method of `wrappedOutputTree`. `typecode` should be the ROOT TBranch type ("F" for float, "I" for int etc.). `lenVar` should be the name of the variable holding the length of array branches (for instance, `branch("Electron_myNewVar","F","nElectron")`). If the `lenVar` branch does not exist already - it can happen if you create a new collection, see an example [here](python/postprocessing/examples/collectionMerger.py)) - it will be automatically created.
 * the `analyze` function is called on each event. It should return `True` if the event is to be retained, `False` if it should be dropped.
+
+### Keep/drop branches
+See the effect of keep/drop instructions by running:
+```
+python scripts/nano_postproc.py outDir /eos/cms/store/user/andrey/f.root -I PhysicsTools.NanoAODTools.postprocessing.examples.exampleModule exampleModuleConstr -s _exaModu_keepdrop --bi scripts/keep_and_drop_input.txt --bo scripts/keep_and_drop_output.txt
+```
+comparing to the previous command (without `--bi` and `--bo`).
+The output branch created by _exampleModuleConstr_ produces the same result in both cases. But this one drops all other branches when creating output tree. It also runs faster.
 
 The event interface, defined in `PhysicsTools.NanoAODTools.postprocessing.framework.datamodule`, allows to dynamically construct views of objects organized in collections, based on the branch names, for instance:
 
@@ -69,14 +78,13 @@ and this will access the elements of the `Electron_someVar`, `Electron_pt` branc
 
 The output branches should be filled calling the `fillBranch(branchname, value)` method of `wrappedOutputTree`. `value` should be the desired value for single-value branches, an iterable with the correct length for array branches. It is not necessary to fill the `lenVar` branch explicitly, as this is done automatically using the length of the passed iterable.
 
-## Keep/drop branches
-See the effect of keep/drop instructions by running:
+
+### mht producer
+Now, let's have a look at another example, `python/postprocessing/examples/mhtjuProducerCpp.py`, [file](python/postprocessing/examples/mhtjuProducerCpp.py). Similarly, it should be imported using the following syntax:
+
 ```
-python scripts/nano_postproc.py outDir /eos/user/a/andrey/f.root -I PhysicsTools.NanoAODTools.postprocessing.examples.exampleModule exampleModule -s _exaModu_keepdrop --bi scripts/keep_and_drop_input.txt --bo scripts/keep_and_drop_output.txt
+python scripts/nano_postproc.py -I PhysicsTools.NanoAODTools.postprocessing.examples.mhtjuProducerCpp mhtju
 ```
-comparing to:
-```
-python scripts/nano_postproc.py outDir /eos/user/a/andrey/f.root -I PhysicsTools.NanoAODTools.postprocessing.examples.exampleModule exampleModule -s _exaModu
-```
-The output branch created by exampleModule produces the same result in both cases. But thefirst one drops all other branches when creating output tree. It also runs faster.
+This module has the same structure of its producer as `exampleProducer`. However, in addition it utilizes a C++ code to calculate the mht variable, `src/mhtjuProducerCppWorker.cc`. This code is loaded in the `__init__` method of the producer.
+
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Please run with `--help` for a complete list of options.
 It is possible to import modules that will be run on each entry passing the event selection, and can be used to calculate new variables that will be included in the output tree (both in friend and full mode) or to apply event filter decisions.
 
 We will use `python/postprocessing/examples/exampleModule.py` as an example. The module definition [file](python/postprocessing/examples/exampleModule.py), containing a simple constructor
-
+```
    exampleModuleConstr = lambda : exampleProducer(jetSelection= lambda j : j.pt > 30)
-
+```
 should be imported using the following syntax:
 
 ```

--- a/interface/mhtjuProducerCppWorker.h
+++ b/interface/mhtjuProducerCppWorker.h
@@ -4,7 +4,8 @@
 #include <utility>
 #include <TTreeReaderValue.h>
 #include <TTreeReaderArray.h>
-#include "DataFormats/Math/interface/LorentzVector.h"
+//#include "DataFormats/Math/interface/LorentzVector.h"
+#include <TLorentzVector.h>
 
 class mhtjuProducerCppWorker {
 

--- a/python/postprocessing/examples/exampleModule.py
+++ b/python/postprocessing/examples/exampleModule.py
@@ -35,5 +35,5 @@ class exampleProducer(Module):
 
 # define modules using the syntax 'name = lambda : constructor' to avoid having them loaded when not needed
 
-exampleModule = lambda : exampleProducer(jetSelection= lambda j : j.pt > 30) 
+exampleModuleConstr = lambda : exampleProducer(jetSelection= lambda j : j.pt > 30) 
  

--- a/scripts/keep_and_drop.txt
+++ b/scripts/keep_and_drop.txt
@@ -1,5 +1,6 @@
 # this is a comment
-drop * # start with all
-keep Electron*
+#keep *
+drop *
 keep Muon*
+keep Electron*
 keep Jet*

--- a/scripts/keep_and_drop_input.txt
+++ b/scripts/keep_and_drop_input.txt
@@ -1,5 +1,5 @@
 # this is a comment
-drop * # start with all
-keep Electron*
+drop *
 keep Muon*
+keep Electron*
 keep Jet*

--- a/scripts/keep_and_drop_output.txt
+++ b/scripts/keep_and_drop_output.txt
@@ -1,0 +1,2 @@
+# this is a comment
+drop *

--- a/scripts/nano_postproc.py
+++ b/scripts/nano_postproc.py
@@ -12,6 +12,8 @@ if __name__ == "__main__":
     parser.add_option("-J", "--json",  dest="json", type="string", default=None, help="Select events using this JSON file")
     parser.add_option("-c", "--cut",  dest="cut", type="string", default=None, help="Cut string")
     parser.add_option("-b", "--branch-selection",  dest="branchsel", type="string", default=None, help="Branch selection")
+    parser.add_option("--bi", "--branch-selection-input",  dest="branchsel_in", type="string", default=None, help="Branch selection input")
+    parser.add_option("--bo", "--branch-selection-output",  dest="branchsel_out", type="string", default=None, help="Branch selection output")
     parser.add_option("--friend",  dest="friend", action="store_true", default=False, help="Produce friend trees in output (current default is to produce full trees)")
     parser.add_option("--full",  dest="friend", action="store_false",  default=False, help="Produce full trees in output (this is the current default)")
     parser.add_option("--noout",  dest="noOut", action="store_true",  default=False, help="Do not produce output, just run modules")
@@ -42,6 +44,9 @@ if __name__ == "__main__":
     if options.noOut:
         if len(modules) == 0: 
             raise RuntimeError("Running with --noout and no modules does nothing!")
-    p=PostProcessor(outdir,args,options.cut,options.branchsel,modules,options.compression,options.friend,options.postfix,options.json,options.noOut,options.justcount,outputbranchsel= options.branchsel)
+    if options.branchsel!=None:
+        options.branchsel_in = options.branchsel
+        options.branchsel_out = options.branchsel
+    p=PostProcessor(outdir,args,options.cut,options.branchsel_in,modules,options.compression,options.friend,options.postfix,options.json,options.noOut,options.justcount,outputbranchsel= options.branchsel_out)
     p.run()
 

--- a/src/mhtjuProducerCppWorker.cc
+++ b/src/mhtjuProducerCppWorker.cc
@@ -2,11 +2,14 @@
 
 std::pair<float,float> mhtjuProducerCppWorker::getHT(){
 
-    math::XYZTLorentzVectorF ht(0,0,0,0);
+    //math::XYZTLorentzVectorF ht(0,0,0,0);
+    TLorentzVector ht(0,0,0,0);
 
     unsigned n = (*nJet).Get()[0];
     for (unsigned i=0; i<n; i++){
-      ht += math::PtEtaPhiMLorentzVectorF((*Jet_pt)[i],0,(*Jet_phi)[i],0);
+      TLorentzVector j_add(0,0,0,0);
+      j_add.SetPtEtaPhiM((*Jet_pt)[i],0,(*Jet_phi)[i],0);
+      ht += j_add;
     }
 
     return std::pair<float,float>(ht.Pt(),ht.Phi());


### PR DESCRIPTION
Improved instructions in readme file. Now all should work.
Removed dependency LorentzVector from CMSSW, so the mht producer should works standalone as well.