### PR TITLE
Secondary file input to postprocessor

### DIFF
--- a/python/postprocessing/framework/postprocessor.py
+++ b/python/postprocessing/framework/postprocessor.py
@@ -80,6 +80,10 @@ class PostProcessor :
         t0 = time.clock()
 	totEntriesRead=0
 	for fname in self.inputFiles:
+	    ffnames = []
+	    if "," in fname:
+	        fnames = fname.split(',')
+	        fname, ffnames = fnames[0], fnames[1:]
 
 	    # open input file
 	    inFile = ROOT.TFile.Open(fname)
@@ -94,7 +98,15 @@ class PostProcessor :
 		continue
 	    else:
 		print 'Pre-select %d entries out of %s '%(elist.GetN() if elist else inTree.GetEntries(),inTree.GetEntries())
-		
+		inAddFiles = []
+		inAddTrees = []
+	    for ffname in ffnames:
+		inAddFiles.append(ROOT.TFile.Open(ffname))
+		inAddTree = inAddFiles[-1].Get("Events")
+		if inAddTree == None: inAddTree = inAddFiles[-1].Get("Friends")
+		inAddTrees.append(inAddTree)
+		inTree.AddFriend(inAddTree)
+
 	    if fullClone:
 		# no need of a reader (no event loop), but set up the elist if available
 		if elist: inTree.SetEntryList(elist)

--- a/python/postprocessing/framework/postprocessor.py
+++ b/python/postprocessing/framework/postprocessor.py
@@ -90,6 +90,7 @@ class PostProcessor :
 
 	    #get input tree
 	    inTree = inFile.Get("Events")
+	    if inTree == None: inTree = inFile.Get("Friends")
 	    totEntriesRead+=inTree.GetEntries()
 	    # pre-skimming
 	    elist,jsonFilter = preSkim(inTree, self.json, self.cut)


### PR DESCRIPTION
This PR suggests to modify postprocessor to support friend tree in the input.

Use case: Users have centrally produced NanoAOD root file and Friend tree. 
They want to read branches across two (or >2) files.

Usage:
```
nano_postproc nano_postproc.py --friend -I Some.User.Module userModule nanoAOD.root,friend.root,friend2.root
```
