### PR TITLE
JME module update for 2017 and (preliminary) 2018 JECs

### DIFF
--- a/python/postprocessing/modules/jme/jetRecalib.py
+++ b/python/postprocessing/modules/jme/jetRecalib.py
@@ -103,11 +103,11 @@ jetRecalib2017DEAK8Puppi = lambda : jetRecalib("Fall17_17Nov2017DE_V32_DATA",jet
 jetRecalib2017FAK8Puppi = lambda : jetRecalib("Fall17_17Nov2017F_V32_DATA",jetType="AK8PFPuppi")
 
 jetRecalib2018A = lambda : jetRecalib("Autumn18_RunA_V8_DATA")
-jetRecalib2018B = lambda : jetRecalib("Autumn18_RunA_V8_DATA")
-jetRecalib2018C = lambda : jetRecalib("Autumn18_RunA_V8_DATA")
-jetRecalib2018D = lambda : jetRecalib("Autumn18_RunA_V8_DATA")
+jetRecalib2018B = lambda : jetRecalib("Autumn18_RunB_V8_DATA")
+jetRecalib2018C = lambda : jetRecalib("Autumn18_RunC_V8_DATA")
+jetRecalib2018D = lambda : jetRecalib("Autumn18_RunD_V8_DATA")
 
 jetRecalib2018AAK8Puppi = lambda : jetRecalib("Autumn18_RunA_V8_DATA",jetType="AK8PFPuppi")
-jetRecalib2018BAK8Puppi = lambda : jetRecalib("Autumn18_RunA_V8_DATA",jetType="AK8PFPuppi")
-jetRecalib2018CAK8Puppi = lambda : jetRecalib("Autumn18_RunA_V8_DATA",jetType="AK8PFPuppi")
-jetRecalib2018DAK8Puppi = lambda : jetRecalib("Autumn18_RunA_V8_DATA",jetType="AK8PFPuppi")
+jetRecalib2018BAK8Puppi = lambda : jetRecalib("Autumn18_RunB_V8_DATA",jetType="AK8PFPuppi")
+jetRecalib2018CAK8Puppi = lambda : jetRecalib("Autumn18_RunC_V8_DATA",jetType="AK8PFPuppi")
+jetRecalib2018DAK8Puppi = lambda : jetRecalib("Autumn18_RunD_V8_DATA",jetType="AK8PFPuppi")

--- a/python/postprocessing/modules/jme/jetRecalib.py
+++ b/python/postprocessing/modules/jme/jetRecalib.py
@@ -24,7 +24,7 @@ class jetRecalib(Module):
         self.jmsVals = [1.00, 0.99, 1.01]
         
 
-        self.jesInputFilePath = os.environ['CMSSW_BASE'] + "/src/PhysicsTools/NanoAODTools/data/jme/"
+        self.jesInputFilePath = os.environ['CMSSW_BASE'] + "/src/PhysicsTools/NanoAODTools/data/jme/" 
 
         self.jetReCalibrator = JetReCalibrator(globalTag, jetType , True, self.jesInputFilePath, calculateSeparateCorrections = False, calculateType1METCorrection  = False)
 	
@@ -84,8 +84,30 @@ class jetRecalib(Module):
 
 # define modules using the syntax 'name = lambda : constructor' to avoid having them loaded when not needed
 
-jetRecalib2017B = lambda : jetRecalib("Fall17_17Nov2017B_V6_DATA")
-jetRecalib2017C = lambda : jetRecalib("Fall17_17Nov2017C_V6_DATA")
-jetRecalib2017D = lambda : jetRecalib("Fall17_17Nov2017D_V6_DATA")
-jetRecalib2017E = lambda : jetRecalib("Fall17_17Nov2017E_V6_DATA")
-jetRecalib2017F = lambda : jetRecalib("Fall17_17Nov2017F_V6_DATA")
+jetRecalib2016BCD = lambda : jetRecalib("Summer16_07Aug2017BCD_V11_DATA")
+jetRecalib2016EF = lambda : jetRecalib("Summer16_07Aug2017EF_V11_DATA")
+jetRecalib2016GH = lambda : jetRecalib("Summer16_07Aug2017GH_V11_DATA")
+
+jetRecalib2016BCDAK8Puppi = lambda : jetRecalib("Summer16_07Aug2017BCD_V11_DATA",jetType="AK8PFPuppi")
+jetRecalib2016EFAK8Puppi = lambda : jetRecalib("Summer16_07Aug2017EF_V11_DATA",jetType="AK8PFPuppi")
+jetRecalib2016GHAK8Puppi = lambda : jetRecalib("Summer16_07Aug2017GH_V11_DATA",jetType="AK8PFPuppi")
+
+jetRecalib2017B = lambda : jetRecalib("Fall17_17Nov2017B_V32_DATA")
+jetRecalib2017C = lambda : jetRecalib("Fall17_17Nov2017C_V32_DATA")
+jetRecalib2017DE = lambda : jetRecalib("Fall17_17Nov2017DE_V32_DATA")
+jetRecalib2017F = lambda : jetRecalib("Fall17_17Nov2017F_V32_DATA")
+
+jetRecalib2017BAK8Puppi = lambda : jetRecalib("Fall17_17Nov2017B_V32_DATA",jetType="AK8PFPuppi")
+jetRecalib2017CAK8Puppi = lambda : jetRecalib("Fall17_17Nov2017C_V32_DATA",jetType="AK8PFPuppi")
+jetRecalib2017DEAK8Puppi = lambda : jetRecalib("Fall17_17Nov2017DE_V32_DATA",jetType="AK8PFPuppi")
+jetRecalib2017FAK8Puppi = lambda : jetRecalib("Fall17_17Nov2017F_V32_DATA",jetType="AK8PFPuppi")
+
+jetRecalib2018A = lambda : jetRecalib("Autumn18_RunA_V8_DATA")
+jetRecalib2018B = lambda : jetRecalib("Autumn18_RunA_V8_DATA")
+jetRecalib2018C = lambda : jetRecalib("Autumn18_RunA_V8_DATA")
+jetRecalib2018D = lambda : jetRecalib("Autumn18_RunA_V8_DATA")
+
+jetRecalib2018AAK8Puppi = lambda : jetRecalib("Autumn18_RunA_V8_DATA",jetType="AK8PFPuppi")
+jetRecalib2018BAK8Puppi = lambda : jetRecalib("Autumn18_RunA_V8_DATA",jetType="AK8PFPuppi")
+jetRecalib2018CAK8Puppi = lambda : jetRecalib("Autumn18_RunA_V8_DATA",jetType="AK8PFPuppi")
+jetRecalib2018DAK8Puppi = lambda : jetRecalib("Autumn18_RunA_V8_DATA",jetType="AK8PFPuppi")

--- a/python/postprocessing/modules/jme/jetRecalib.py
+++ b/python/postprocessing/modules/jme/jetRecalib.py
@@ -1,5 +1,5 @@
 import ROOT
-import math, os,re
+import math, os,re, tarfile, tempfile
 import numpy as np
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 
@@ -9,7 +9,7 @@ from PhysicsTools.NanoAODTools.postprocessing.tools import matchObjectCollection
 from PhysicsTools.NanoAODTools.postprocessing.modules.jme.JetReCalibrator import JetReCalibrator
 
 class jetRecalib(Module):
-    def __init__(self,  globalTag, jetType = "AK4PFchs"):
+    def __init__(self,  globalTag, archive, jetType = "AK4PFchs"):
 
         if "AK4" in jetType : 
             self.jetBranchName = "Jet"
@@ -24,7 +24,11 @@ class jetRecalib(Module):
         self.jmsVals = [1.00, 0.99, 1.01]
         
 
-        self.jesInputFilePath = os.environ['CMSSW_BASE'] + "/src/PhysicsTools/NanoAODTools/data/jme/" 
+        self.jesInputArchivePath = os.environ['CMSSW_BASE'] + "/src/PhysicsTools/NanoAODTools/data/jme/"
+        # Text files are now tarred so must extract first into temporary directory (gets deleted during python memory management at script exit)
+        self.jesArchive = tarfile.open(self.jesInputArchivePath+archive+".tgz", "r:gz")
+        self.jesInputFilePath = tempfile.mkdtemp()
+        self.jesArchive.extractall(self.jesInputFilePath)
 
         self.jetReCalibrator = JetReCalibrator(globalTag, jetType , True, self.jesInputFilePath, calculateSeparateCorrections = False, calculateType1METCorrection  = False)
 	
@@ -83,31 +87,30 @@ class jetRecalib(Module):
 
 
 # define modules using the syntax 'name = lambda : constructor' to avoid having them loaded when not needed
+jetRecalib2016BCD = lambda : jetRecalib("Summer16_07Aug2017BCD_V11_DATA","Summer16_07Aug2017_V11_DATA")
+jetRecalib2016EF = lambda : jetRecalib("Summer16_07Aug2017EF_V11_DATA","Summer16_07Aug2017_V11_DATA")
+jetRecalib2016GH = lambda : jetRecalib("Summer16_07Aug2017GH_V11_DATA","Summer16_07Aug2017_V11_DATA")
 
-jetRecalib2016BCD = lambda : jetRecalib("Summer16_07Aug2017BCD_V11_DATA")
-jetRecalib2016EF = lambda : jetRecalib("Summer16_07Aug2017EF_V11_DATA")
-jetRecalib2016GH = lambda : jetRecalib("Summer16_07Aug2017GH_V11_DATA")
+jetRecalib2016BCDAK8Puppi = lambda : jetRecalib("Summer16_07Aug2017BCD_V11_DATA","Summer16_07Aug2017_V11_DATA", jetType="AK8PFPuppi")
+jetRecalib2016EFAK8Puppi = lambda : jetRecalib("Summer16_07Aug2017EF_V11_DATA","Summer16_07Aug2017_V11_DATA", jetType="AK8PFPuppi")
+jetRecalib2016GHAK8Puppi = lambda : jetRecalib("Summer16_07Aug2017GH_V11_DATA","Summer16_07Aug2017_V11_DATA",jetType="AK8PFPuppi")
 
-jetRecalib2016BCDAK8Puppi = lambda : jetRecalib("Summer16_07Aug2017BCD_V11_DATA",jetType="AK8PFPuppi")
-jetRecalib2016EFAK8Puppi = lambda : jetRecalib("Summer16_07Aug2017EF_V11_DATA",jetType="AK8PFPuppi")
-jetRecalib2016GHAK8Puppi = lambda : jetRecalib("Summer16_07Aug2017GH_V11_DATA",jetType="AK8PFPuppi")
+jetRecalib2017B = lambda : jetRecalib("Fall17_17Nov2017B_V32_DATA","Fall17_17Nov2017_V32_DATA")
+jetRecalib2017C = lambda : jetRecalib("Fall17_17Nov2017C_V32_DATA","Fall17_17Nov2017_V32_DATA")
+jetRecalib2017DE = lambda : jetRecalib("Fall17_17Nov2017DE_V32_DATA","Fall17_17Nov2017_V32_DATA")
+jetRecalib2017F = lambda : jetRecalib("Fall17_17Nov2017F_V32_DATA","Fall17_17Nov2017_V32_DATA")
 
-jetRecalib2017B = lambda : jetRecalib("Fall17_17Nov2017B_V32_DATA")
-jetRecalib2017C = lambda : jetRecalib("Fall17_17Nov2017C_V32_DATA")
-jetRecalib2017DE = lambda : jetRecalib("Fall17_17Nov2017DE_V32_DATA")
-jetRecalib2017F = lambda : jetRecalib("Fall17_17Nov2017F_V32_DATA")
+jetRecalib2017BAK8Puppi = lambda : jetRecalib("Fall17_17Nov2017B_V32_DATA","Fall17_17Nov2017_V32_DATA",jetType="AK8PFPuppi")
+jetRecalib2017CAK8Puppi = lambda : jetRecalib("Fall17_17Nov2017C_V32_DATA","Fall17_17Nov2017_V32_DATA",jetType="AK8PFPuppi")
+jetRecalib2017DEAK8Puppi = lambda : jetRecalib("Fall17_17Nov2017DE_V32_DATA","Fall17_17Nov2017_V32_DATA", jetType="AK8PFPuppi")
+jetRecalib2017FAK8Puppi = lambda : jetRecalib("Fall17_17Nov2017F_V32_DATA","Fall17_17Nov2017_V32_DATA",jetType="AK8PFPuppi")
 
-jetRecalib2017BAK8Puppi = lambda : jetRecalib("Fall17_17Nov2017B_V32_DATA",jetType="AK8PFPuppi")
-jetRecalib2017CAK8Puppi = lambda : jetRecalib("Fall17_17Nov2017C_V32_DATA",jetType="AK8PFPuppi")
-jetRecalib2017DEAK8Puppi = lambda : jetRecalib("Fall17_17Nov2017DE_V32_DATA",jetType="AK8PFPuppi")
-jetRecalib2017FAK8Puppi = lambda : jetRecalib("Fall17_17Nov2017F_V32_DATA",jetType="AK8PFPuppi")
+jetRecalib2018A = lambda : jetRecalib("Autumn18_RunA_V8_DATA","Autumn18_V8_DATA")
+jetRecalib2018B = lambda : jetRecalib("Autumn18_RunB_V8_DATA","Autumn18_V8_DATA")
+jetRecalib2018C = lambda : jetRecalib("Autumn18_RunC_V8_DATA","Autumn18_V8_DATA")
+jetRecalib2018D = lambda : jetRecalib("Autumn18_RunD_V8_DATA","Autumn18_V8_DATA")
 
-jetRecalib2018A = lambda : jetRecalib("Autumn18_RunA_V8_DATA")
-jetRecalib2018B = lambda : jetRecalib("Autumn18_RunB_V8_DATA")
-jetRecalib2018C = lambda : jetRecalib("Autumn18_RunC_V8_DATA")
-jetRecalib2018D = lambda : jetRecalib("Autumn18_RunD_V8_DATA")
-
-jetRecalib2018AAK8Puppi = lambda : jetRecalib("Autumn18_RunA_V8_DATA",jetType="AK8PFPuppi")
-jetRecalib2018BAK8Puppi = lambda : jetRecalib("Autumn18_RunB_V8_DATA",jetType="AK8PFPuppi")
-jetRecalib2018CAK8Puppi = lambda : jetRecalib("Autumn18_RunC_V8_DATA",jetType="AK8PFPuppi")
-jetRecalib2018DAK8Puppi = lambda : jetRecalib("Autumn18_RunD_V8_DATA",jetType="AK8PFPuppi")
+jetRecalib2018AAK8Puppi = lambda : jetRecalib("Autumn18_RunA_V8_DATA","Autumn18_V8_DATA",jetType="AK8PFPuppi")
+jetRecalib2018BAK8Puppi = lambda : jetRecalib("Autumn18_RunB_V8_DATA","Autumn18_V8_DATA",jetType="AK8PFPuppi")
+jetRecalib2018CAK8Puppi = lambda : jetRecalib("Autumn18_RunC_V8_DATA","Autumn18_V8_DATA",jetType="AK8PFPuppi")
+jetRecalib2018DAK8Puppi = lambda : jetRecalib("Autumn18_RunD_V8_DATA","Autumn18_V8_DATA",jetType="AK8PFPuppi")

--- a/python/postprocessing/modules/jme/jetRecalib.py
+++ b/python/postprocessing/modules/jme/jetRecalib.py
@@ -19,10 +19,7 @@ class jetRecalib(Module):
         else:
             raise ValueError("ERROR: Invalid jet type = '%s'!" % jetType)
         self.rhoBranchName = "fixedGridRhoFastjetAll"
-        self.lenVar = "n" + self.jetBranchName
-        # To do : change to real values
-        self.jmsVals = [1.00, 0.99, 1.01]
-        
+        self.lenVar = "n" + self.jetBranchName        
 
         self.jesInputArchivePath = os.environ['CMSSW_BASE'] + "/src/PhysicsTools/NanoAODTools/data/jme/"
         # Text files are now tarred so must extract first into temporary directory (gets deleted during python memory management at script exit)

--- a/python/postprocessing/modules/jme/jetSmearer.py
+++ b/python/postprocessing/modules/jme/jetSmearer.py
@@ -1,5 +1,5 @@
 import ROOT
-import math, os, tarfile
+import math, os, tarfile, tempfile
 import numpy as np
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 
@@ -21,7 +21,7 @@ class jetSmearer(Module):
         self.jerInputArchivePath = os.environ['CMSSW_BASE'] + "/src/PhysicsTools/NanoAODTools/data/jme/"
         self.jerTag = jerInputFileName[:jerInputFileName.find('_MC_')+len('_MC')]
         self.jerArchive = tarfile.open(self.jerInputArchivePath+self.jerTag+".tgz", "r:gz")
-        self.jerInputFilePath = "scratch/"+self.jerTag
+        self.jerInputFilePath = tempfile.mkdtemp()
         self.jerArchive.extractall(self.jerInputFilePath)
         self.jerInputFileName = jerInputFileName
         self.jerUncertaintyInputFileName = jerUncertaintyInputFileName

--- a/python/postprocessing/modules/jme/jetSmearer.py
+++ b/python/postprocessing/modules/jme/jetSmearer.py
@@ -17,7 +17,12 @@ class jetSmearer(Module):
 
         # read jet energy resolution (JER) and JER scale factors and uncertainties
         # (the txt files were downloaded from https://github.com/cms-jet/JRDatabase/tree/master/textFiles/Spring16_25nsV10_MC )
-        self.jerInputFilePath = os.environ['CMSSW_BASE'] + "/src/PhysicsTools/NanoAODTools/data/jme/"
+        # Text files are now tarred so must extract first
+        self.jerArchiveFilePath = os.environ['CMSSW_BASE'] + "/src/PhysicsTools/NanoAODTools/data/jme/"
+        self.jerTag = jerInputFileName[:jerInputFileName.find('_MC_')+len('_MC')]
+        self.jerArchive = tarfile.open(self.jerInputArchivePath+globalTag+".tgz", "r:gz")
+        self.jerInputFilePath = "scratch/"+self.jerTag
+        self.jerArchive.extractall(self.jerInputFilePath)
         self.jerInputFileName = jerInputFileName
         self.jerUncertaintyInputFileName = jerUncertaintyInputFileName
 

--- a/python/postprocessing/modules/jme/jetSmearer.py
+++ b/python/postprocessing/modules/jme/jetSmearer.py
@@ -18,7 +18,7 @@ class jetSmearer(Module):
         # read jet energy resolution (JER) and JER scale factors and uncertainties
         # (the txt files were downloaded from https://github.com/cms-jet/JRDatabase/tree/master/textFiles/Spring16_25nsV10_MC )
         # Text files are now tarred so must extract first
-        self.jerArchiveFilePath = os.environ['CMSSW_BASE'] + "/src/PhysicsTools/NanoAODTools/data/jme/"
+        self.jerInputArchivePath = os.environ['CMSSW_BASE'] + "/src/PhysicsTools/NanoAODTools/data/jme/"
         self.jerTag = jerInputFileName[:jerInputFileName.find('_MC_')+len('_MC')]
         self.jerArchive = tarfile.open(self.jerInputArchivePath+globalTag+".tgz", "r:gz")
         self.jerInputFilePath = "scratch/"+self.jerTag

--- a/python/postprocessing/modules/jme/jetSmearer.py
+++ b/python/postprocessing/modules/jme/jetSmearer.py
@@ -1,5 +1,5 @@
 import ROOT
-import math, os
+import math, os, tarfile
 import numpy as np
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 

--- a/python/postprocessing/modules/jme/jetSmearer.py
+++ b/python/postprocessing/modules/jme/jetSmearer.py
@@ -20,7 +20,7 @@ class jetSmearer(Module):
         # Text files are now tarred so must extract first
         self.jerInputArchivePath = os.environ['CMSSW_BASE'] + "/src/PhysicsTools/NanoAODTools/data/jme/"
         self.jerTag = jerInputFileName[:jerInputFileName.find('_MC_')+len('_MC')]
-        self.jerArchive = tarfile.open(self.jerInputArchivePath+globalTag+".tgz", "r:gz")
+        self.jerArchive = tarfile.open(self.jerInputArchivePath+self.jerTag+".tgz", "r:gz")
         self.jerInputFilePath = "scratch/"+self.jerTag
         self.jerArchive.extractall(self.jerInputFilePath)
         self.jerInputFileName = jerInputFileName

--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -1,5 +1,5 @@
 import ROOT
-import math, os,re, tarfile
+import math, os,re, tarfile, shutil
 import numpy as np
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 

--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -1,5 +1,5 @@
 import ROOT
-import math, os,re, tarfile, shutil
+import math, os,re, tarfile, tempfile
 import numpy as np
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 
@@ -60,9 +60,9 @@ class jetmetUncertaintiesProducer(Module):
         # read jet energy scale (JES) uncertainties
         # (downloaded from https://twiki.cern.ch/twiki/bin/view/CMS/JECDataMC )
         self.jesInputArchivePath = os.environ['CMSSW_BASE'] + "/src/PhysicsTools/NanoAODTools/data/jme/"
-        # Text files are now tarred so must extract first
+        # Text files are now tarred so must extract first into temporary directory (gets deleted during python memory management at script exit)
         self.jesArchive = tarfile.open(self.jesInputArchivePath+globalTag+".tgz", "r:gz")
-        self.jesInputFilePath = "scratch/"+globalTag
+        self.jesInputFilePath = tempfile.mkdtemp()
         self.jesArchive.extractall(self.jesInputFilePath)
         
         if len(jesUncertainties) == 1 and jesUncertainties[0] == "Total":
@@ -125,7 +125,6 @@ class jetmetUncertaintiesProducer(Module):
         self.jetSmearer.beginJob()
 
     def endJob(self):
-        shutil.rmtree("scratch/")
         self.jetSmearer.endJob()
 
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):

--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -87,7 +87,7 @@ class jetmetUncertaintiesProducer(Module):
 
         # read all uncertainty source names from the loaded file
         if jesUncertainties[0] == "All":
-            with open(self.jesInputFilePath+self.jesUncertaintyInputFileName) as f:
+            with open(self.jesInputFilePath+'/'+self.jesUncertaintyInputFileName) as f:
                 lines = f.read().split("\n")
                 sources = filter(lambda x: x.startswith("[") and x.endswith("]"), lines)
                 sources = map(lambda x: x[1:-1], sources)
@@ -446,7 +446,7 @@ jetmetUncertainties2017 = lambda : jetmetUncertaintiesProducer("2017", "Fall17_1
 jetmetUncertainties2017All = lambda : jetmetUncertaintiesProducer("2017", "Fall17_17Nov2017_V32_MC", [ "All" ], redoJEC=True)
 
 jetmetUncertainties2018 = lambda : jetmetUncertaintiesProducer("2018", "Autumn18_V8_MC", [ "Total" ])
-jetmetUncertainties2018All = lambda : jetmetUncertaintiesProducer("2018", "Autumn18_V8_MC", [ "All" ])
+jetmetUncertainties2018All = lambda : jetmetUncertaintiesProducer("2018", "Autumn18_V8_MC", [ "All" ], redoJEC=True)
 
 
 jetmetUncertainties2016AK4Puppi = lambda : jetmetUncertaintiesProducer("2016", "Summer16_23Sep2016V4_MC", [ "Total" ], jetType="AK4PFPuppi")

--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -125,7 +125,7 @@ class jetmetUncertaintiesProducer(Module):
         self.jetSmearer.beginJob()
 
     def endJob(self):
-
+        shutil.rmtree("scratch/")
         self.jetSmearer.endJob()
 
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):

--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -25,7 +25,7 @@ class jetmetUncertaintiesProducer(Module):
         # smear jet pT to account for measured difference in JER between data and simulation.
         if era == "2016":
             self.jerInputFileName = "Summer16_25nsV1_MC_PtResolution_" + jetType + ".txt"
-            self.jerUncertaintyInputFileName = "Summer16_25nsV1_25nsV10_MC_SF_" + jetType + ".txt"
+            self.jerUncertaintyInputFileName = "Summer16_25nsV1_MC_SF_" + jetType + ".txt"
         elif era == "2017" or era == "2018": # use Fall17 as temporary placeholder until post-Moriond 2019 JERs are out
             self.jerInputFileName = "Fall17_V3_MC_PtResolution_" + jetType + ".txt"
             self.jerUncertaintyInputFileName = "Fall17_V3_MC_SF_" + jetType + ".txt"


### PR DESCRIPTION
Module updates separated out from PR #126.

Accommodates the fact that JECs will be stored in tgz files now.