### PR TITLE
Support for missing branches in cutstring when skimming

### DIFF
--- a/python/postprocessing/framework/preskimming.py
+++ b/python/postprocessing/framework/preskimming.py
@@ -1,4 +1,5 @@
 import json
+import re
 import ROOT
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 class JSONFilter:
@@ -60,6 +61,11 @@ def preSkim(tree, jsonInput = None, cutstring = None, maxEntries = None, firstEn
     if cutstring != None: 
         cut = "(%s) && (%s)" % (cutstring, cut) if cut else cutstring
     if maxEntries is None: maxEntries = ROOT.TVirtualTreePlayer.kMaxEntries
+    while "AltBranch$" in cut:
+        m = re.search(r"AltBranch\$\(\s*(\w+)\s*,\s*(\w+)\s*\)", cut)
+        if not m:
+            raise RuntimeError("Error, found AltBranch$ in cut string, but it doesn't comply with the syntax this code can support. The cut is %r" % cut)
+        cut = cut.replace(m.group(0), m.group(1) if tree.GetBranch(m.group(1)) else m.group(2))
     tree.Draw('>>elist',cut,"entrylist", maxEntries, firstEntry)
     elist = ROOT.gDirectory.Get('elist')
     if jsonInput:


### PR DESCRIPTION
Add a feature to support skimming with a cutstring when some branches may be missing. The main usecase is to skim with a cutstring in the form `HLT_Path1 || HLT_Path2  || HLT_Path3` when a path may be missing in some runs and thus in some input files.

It seems like `Alt$(name,0)` does not work for this case, as a missing branch still raises an error.

So, this PR adds a syntax `AltBranch$(name,value)` , or `AltBranch$(name,name2)`,  where the preprocessor checks once if the branch exists and replaces the expression with the proper value.

@peruzzim 