### PR TITLE
Make Module class a new-style class

### DIFF
--- a/python/postprocessing/framework/eventloop.py
+++ b/python/postprocessing/framework/eventloop.py
@@ -3,7 +3,7 @@ from PhysicsTools.NanoAODTools.postprocessing.framework.treeReaderArrayTools imp
 import sys, time
 import ROOT
 
-class Module:
+class Module(object):
     def __init__(self):
         self.writeHistFile=False
     def beginJob(self,histFile=None,histDirName=None):


### PR DESCRIPTION
Defining the `Module` class with
```
class Module(object):
    ...
```
makes it a new-style class, allowing `super()` to be used in subclasses, e.g.
```
class MyModule(Module):
    def __init__(self,*args):
        super(MyModule,self).__init__()
        ...

class MySubModule(MyModule):
    def __init__(self,*args):
        super(MySubModule,self).__init__(*args)
        ...
```
Without this, there will be type error because of the use of `super`:
```TypeError: must be type, not classobj```

See e.g. https://stackoverflow.com/a/1713052