### PR TITLE
Fix maxEvents range when not skimming (was missing last event)

### DIFF
--- a/python/postprocessing/framework/eventloop.py
+++ b/python/postprocessing/framework/eventloop.py
@@ -51,7 +51,7 @@ def eventLoop(modules, inputFile, outputFile, inputTree, wrappedOutputTree, maxE
     entries = inputTree.entries
 
     for i in xrange(entries) if eventRange == None else eventRange:
-        if maxEvents > 0 and i >= maxEvents-1: break
+        if maxEvents > 0 and i >= maxEvents: break
         e = Event(inputTree,i)
         clearExtraBranches(inputTree)
         doneEvents += 1


### PR DESCRIPTION
Trivial fix, but important if one is producing friend trees splitting a single input file in multiple tasks processing different ranges of entries.
@peruzzim 

@fgolf given it's a trivial bugfix I'll merge it directly