### PR TITLE
Implemented simple iterator for Collection

### DIFF
--- a/python/postprocessing/framework/datamodel.py
+++ b/python/postprocessing/framework/datamodel.py
@@ -91,4 +91,7 @@ class Collection:
         return ret
     def __len__(self):
         return self._len
+    def __iter__(self):
+        for index in range(self._len):
+            yield self[index]
 


### PR DESCRIPTION
The iterator has been implemented as a generator.
The internal length of the Collection is used to iterate on contained Objects. 

Tested in CMSSW_10_2_0