### PR TITLE
Add DeltaR to Object class

### DIFF
--- a/python/postprocessing/framework/datamodel.py
+++ b/python/postprocessing/framework/datamodel.py
@@ -1,4 +1,5 @@
 import ROOT
+import math
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 from PhysicsTools.NanoAODTools.postprocessing.framework.treeReaderArrayTools import InputTree 
 
@@ -67,6 +68,16 @@ class Object:
         ret = ROOT.TLorentzVector()
         ret.SetPtEtaPhiM(self.pt,self.eta,self.phi,self.mass)
         return ret
+    def DeltaR(self,other):
+        if isinstance(other,ROOT.TLorentzVector):
+          deta = abs(other.Eta()-self.eta)
+          dphi = abs(other.Phi()-self.phi)
+        else:
+          deta = abs(other.eta-self.eta)
+          dphi = abs(other.phi-self.phi)
+        while dphi > math.pi:
+          dphi = abs(dphi - 2*math.pi)
+        return math.sqrt(dphi**2+deta**2)
     def subObj(self,prefix):
         return Object(self._event,self._prefix+prefix)
     def __repr__(self):


### PR DESCRIPTION
Added simple class method to quickly compute the DeltaR between two objects without the need to create the `TLorentzVector` objects, e.g.
```
if event.nMuon>=2:
  muons = Collection(event,'Muon')
  dR0 = muons[0].p4().DeltaR(muons[1].p4()) # create two TLorentzVectors on the fly
  dR1 = muons[0].DeltaR(muons[1])           # using this new method
  dR2 = muons[0].DeltaR(muons[1].p4())      # using this new method, passing TLorentzVector
``` 
Comparing these three methods for a large number of events, I found no difference between them beyond rounding errors sometimes, with a relative difference on the order of 10^-16.