### PR TITLE
Adding JMS/JMR corrections to softdrop mass  for tau21DDT<=0.43 + bugfix in JetReCalibrator.py

### DIFF
--- a/python/postprocessing/modules/jme/JetReCalibrator.py
+++ b/python/postprocessing/modules/jme/JetReCalibrator.py
@@ -16,7 +16,7 @@ class JetReCalibrator:
         self.doResidualJECs = doResidualJECs
         self.jecPath = jecPath
         self.upToLevel = upToLevel
-        self.calculateType1METCorr = calculateType1METCorrection
+        self.calculateType1METCorrection = calculateType1METCorrection
         self.calculateSeparateCorrections = calculateSeparateCorrections
         self.type1METParams  = type1METParams
         # Make base corrections

--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -142,6 +142,7 @@ class jetmetUncertaintiesProducer(Module):
         if self.doGroomed:
             self.out.branch("%s_msoftdrop_raw" % self.jetBranchName, "F", lenVar=self.lenVar)
             self.out.branch("%s_msoftdrop_nom" % self.jetBranchName, "F", lenVar=self.lenVar)
+            self.out.branch("%s_msoftdrop_tau21DDT_nom" % self.jetBranchName, "F", lenVar=self.lenVar)
             self.out.branch("%s_msoftdrop_corr_JMR" % self.jetBranchName, "F", lenVar=self.lenVar)
             self.out.branch("%s_msoftdrop_corr_JMS" % self.jetBranchName, "F", lenVar=self.lenVar)
             self.out.branch("%s_msoftdrop_corr_PUPPI" % self.jetBranchName, "F", lenVar=self.lenVar)
@@ -160,6 +161,10 @@ class jetmetUncertaintiesProducer(Module):
                 self.out.branch("%s_msoftdrop_jer%s" % (self.jetBranchName, shift), "F", lenVar=self.lenVar)
                 self.out.branch("%s_msoftdrop_jmr%s" % (self.jetBranchName, shift), "F", lenVar=self.lenVar)
                 self.out.branch("%s_msoftdrop_jms%s" % (self.jetBranchName, shift), "F", lenVar=self.lenVar)
+                self.out.branch("%s_msoftdrop_tau21DDT_jer%s" % (self.jetBranchName, shift), "F", lenVar=self.lenVar)
+                self.out.branch("%s_msoftdrop_tau21DDT_jmr%s" % (self.jetBranchName, shift), "F", lenVar=self.lenVar)
+                self.out.branch("%s_msoftdrop_tau21DDT_jms%s" % (self.jetBranchName, shift), "F", lenVar=self.lenVar)
+
 
             if self.corrMET :
                 self.out.branch("%s_pt_jer%s" % (self.metBranchName, shift), "F")
@@ -249,6 +254,13 @@ class jetmetUncertaintiesProducer(Module):
             jets_msdcorr_jesDown = {}
             jets_msdcorr_jmsUp   = []
             jets_msdcorr_jmsDown = []
+            jets_msdcorr_tau21DDT_nom = []
+            jets_msdcorr_tau21DDT_jerUp = []
+            jets_msdcorr_tau21DDT_jerDown = []
+            jets_msdcorr_tau21DDT_jmrUp = []
+            jets_msdcorr_tau21DDT_jmrDown = []
+            jets_msdcorr_tau21DDT_jmsUp = []
+            jets_msdcorr_tau21DDT_jmsDown = []
             for jesUncertainty in self.jesUncertainties:
                 jets_msdcorr_jesUp[jesUncertainty]   = []
                 jets_msdcorr_jesDown[jesUncertainty] = []
@@ -363,6 +375,37 @@ class jetmetUncertaintiesProducer(Module):
                 jets_msdcorr_jmrDown.append(jet_pt_jerNomVal *jet_msdcorr_jmrDownVal*jmsNomVal  *jet_msdcorr_raw)
                 jets_msdcorr_jmsUp  .append(jet_pt_jerNomVal *jet_msdcorr_jmrNomVal *jmsUpVal   *jet_msdcorr_raw)
                 jets_msdcorr_jmsDown.append(jet_pt_jerNomVal *jet_msdcorr_jmrNomVal *jmsDownVal *jet_msdcorr_raw)
+
+                #Also evaluated JMS&JMR SD corr in tau21DDT region: https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetWtagging#tau21DDT_0_43
+                tmp_jmsVals = self.jmsVals
+                tmp_jmrVals = self.jmrVals
+                if self.era in ["2016"]:
+                    self.jmsVals = [1.014,1.007,1.021]
+                    self.jmrVals = [1.086,1.176,0.996]
+                elif self.era in ["2017"]:
+                    self.jmsVals = [0.983,0.976,0.99]
+                    self.jmrVals = [1.080,1.161,0.999]
+                jmsNomVal = self.jmsVals[0]
+                jmsDownVal = self.jmsVals[1]
+                jmsUpVal = self.jmsVals[2]
+
+                ( jet_msdcorr_tau21DDT_jmrNomVal, jet_msdcorr_tau21DDT_jmrUpVal, jet_msdcorr_tau21DDT_jmrDownVal ) = self.jetSmearer.getSmearValsM(groomedP4, genGroomedJet) if groomedP4 != None and genGroomedJet != None else (0.,0.,0.)
+                jet_msdcorr_tau21DDT_nom           = jet_pt_jerNomVal*jet_msdcorr_tau21DDT_jmrNomVal*jmsNomVal*jet_msdcorr_raw
+                jets_msdcorr_tau21DDT_nom    .append(jet_msdcorr_tau21DDT_nom)
+                jets_msdcorr_tau21DDT_jerUp  .append(jet_pt_jerUpVal  *jet_msdcorr_tau21DDT_jmrNomVal *jmsNomVal  *jet_msdcorr_raw)
+                jets_msdcorr_tau21DDT_jerDown.append(jet_pt_jerDownVal*jet_msdcorr_tau21DDT_jmrNomVal *jmsNomVal  *jet_msdcorr_raw)
+                jets_msdcorr_tau21DDT_jmrUp  .append(jet_pt_jerNomVal *jet_msdcorr_tau21DDT_jmrUpVal  *jmsNomVal  *jet_msdcorr_raw)
+                jets_msdcorr_tau21DDT_jmrDown.append(jet_pt_jerNomVal *jet_msdcorr_tau21DDT_jmrDownVal*jmsNomVal  *jet_msdcorr_raw)
+                jets_msdcorr_tau21DDT_jmsUp  .append(jet_pt_jerNomVal *jet_msdcorr_tau21DDT_jmrNomVal *jmsUpVal   *jet_msdcorr_raw)
+                jets_msdcorr_tau21DDT_jmsDown.append(jet_pt_jerNomVal *jet_msdcorr_tau21DDT_jmrNomVal *jmsDownVal *jet_msdcorr_raw)
+
+                #Now restore the original values of self.jmsVals, self.jmrVals and jmsNomVal, jmsDownVal, jmsUpVal:
+                self.jmsVals = tmp_jmsVals
+                self.jmrVals = tmp_jmrVals
+                jmsNomVal = self.jmsVals[0]
+                jmsDownVal = self.jmsVals[1]
+                jmsUpVal = self.jmsVals[2]
+
             
             for jesUncertainty in self.jesUncertainties:
                 # (cf. https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyCorrections#JetCorUncertainties )
@@ -455,6 +498,13 @@ class jetmetUncertaintiesProducer(Module):
             self.out.fillBranch("%s_msoftdrop_jmrDown" % self.jetBranchName, jets_msdcorr_jmrDown)
             self.out.fillBranch("%s_msoftdrop_jmsUp" % self.jetBranchName, jets_msdcorr_jmsUp)
             self.out.fillBranch("%s_msoftdrop_jmsDown" % self.jetBranchName, jets_msdcorr_jmsDown)
+            self.out.fillBranch("%s_msoftdrop_tau21DDT_nom" % self.jetBranchName, jets_msdcorr_tau21DDT_nom)
+            self.out.fillBranch("%s_msoftdrop_tau21DDT_jerUp" % self.jetBranchName, jets_msdcorr_tau21DDT_jerUp)
+            self.out.fillBranch("%s_msoftdrop_tau21DDT_jerDown" % self.jetBranchName, jets_msdcorr_tau21DDT_jerDown)
+            self.out.fillBranch("%s_msoftdrop_tau21DDT_jmrUp" % self.jetBranchName, jets_msdcorr_tau21DDT_jmrUp)
+            self.out.fillBranch("%s_msoftdrop_tau21DDT_jmrDown" % self.jetBranchName, jets_msdcorr_tau21DDT_jmrDown)
+            self.out.fillBranch("%s_msoftdrop_tau21DDT_jmsUp" % self.jetBranchName, jets_msdcorr_tau21DDT_jmsUp)
+            self.out.fillBranch("%s_msoftdrop_tau21DDT_jmsDown" % self.jetBranchName, jets_msdcorr_tau21DDT_jmsDown)
 
             
         if self.corrMET :


### PR DESCRIPTION
PR with changes in jetmetUncertainties.py made on behalf of @GLP90 who implemented this on a private branch some time ago - PR to avoid diverging from this central repository.

Changes in JetReCalibator.py needed because currently the jme uncertainties module will break if redoJEC=True.