### PR TITLE
Remove files that were unpacked from JES & JER tarballs to a temp dir

### DIFF
--- a/python/postprocessing/modules/jme/jetRecalib.py
+++ b/python/postprocessing/modules/jme/jetRecalib.py
@@ -1,5 +1,5 @@
 import ROOT
-import math, os,re, tarfile, tempfile
+import math, os,re, tarfile, tempfile, shutil
 import numpy as np
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 
@@ -46,7 +46,7 @@ class jetRecalib(Module):
 	pass
 
     def endJob(self):
-	pass
+	shutil.rmtree(self.jesInputFilePath)
 
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         self.out = wrappedOutputTree

--- a/python/postprocessing/modules/jme/jetSmearer.py
+++ b/python/postprocessing/modules/jme/jetSmearer.py
@@ -1,5 +1,5 @@
 import ROOT
-import math, os, tarfile, tempfile
+import math, os, tarfile, tempfile, shutil
 import numpy as np
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 
@@ -54,9 +54,8 @@ class jetSmearer(Module):
         self.jerSF_and_Uncertainty = ROOT.PyJetResolutionScaleFactorWrapper(os.path.join(self.jerInputFilePath, self.jerUncertaintyInputFileName))
         
     def endJob(self):
-        pass
-        
-    
+        shutil.rmtree(self.jerInputFilePath)
+
     def setSeed(self,event):
         """Set seed deterministically."""
         # (cf. https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h)

--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -1,5 +1,5 @@
 import ROOT
-import math, os,re, tarfile, tempfile
+import math, os,re, tarfile, tempfile, shutil
 import numpy as np
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 
@@ -127,6 +127,7 @@ class jetmetUncertaintiesProducer(Module):
 
     def endJob(self):
         self.jetSmearer.endJob()
+        shutil.rmtree(self.jesInputFilePath)
 
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         self.out = wrappedOutputTree


### PR DESCRIPTION
Found that our local cluster ran out of memory because the files that were unpacked from these tarballs were never removed.