### PR TITLE
remove directory tree listing

### DIFF
--- a/crab/crab_script.py
+++ b/crab/crab_script.py
@@ -10,5 +10,4 @@ p=PostProcessor(".",inputFiles(),"Jet_pt>200",modules=[exampleModuleConstr()],pr
 p.run()
 
 print "DONE"
-os.system("ls -lR")
 


### PR DESCRIPTION
Most users use this script as-is and end un with very long output where the full directory three is printed in each job. Long outputs put strain on submission infrastructure and CRAB servers. Users should only do this when really needed, and for a few jobs. Listing same directory in each job in a task is totally useless. 