### PR TITLE
Backfill Run tree in haddnano to support multi-point signal scans

### DIFF
--- a/scripts/haddnano.py
+++ b/scripts/haddnano.py
@@ -8,12 +8,16 @@ if len(sys.argv) < 3 :
 ofname=sys.argv[1]
 files=sys.argv[2:]
 
-def zeroFill(tree,brName,brObj) :
-	if brObj.GetLeaf(brName).GetTypeName() != "Bool_t" :
+def zeroFill(tree,brName,brObj,allowNonBool=False) :
+	# typename: (numpy type code, root type code)
+	branch_type_dict = {'Bool_t':('?','O'), 'Float_t':('f4','F'), 'UInt_t':('u4','i'), 'Long64_t':('i8','L'), 'Double_t':('f8','D')}
+	brType = brObj.GetLeaf(brName).GetTypeName()
+	if (not allowNonBool) and (brType != "Bool_t") :
 		print "Did not expect to back fill non-boolean branches",tree,brName,brObj.GetLeaf(br).GetTypeName()
 	else :
-		buff=array('B',[0])
-		b=tree.Branch(brName,buff,brName+"/O")
+		if brType not in branch_type_dict: raise RuntimeError, 'Impossible to backfill branch of type %s'%brType
+		buff=numpy.zeros(1,dtype=numpy.dtype(branch_type_dict[brType][0]))
+		b=tree.Branch(brName,buff,brName+"/"+branch_type_dict[brType][1])
 	        b.SetBasketSize(tree.GetEntries()*2) #be sure we do not trigger flushing
 		for x in xrange(0,tree.GetEntries()):	
 			b.Fill()
@@ -38,7 +42,7 @@ for e in fileHandles[0].GetListOfKeys() :
 	cl=ROOT.TClass.GetClass(e.GetClassName())
 	inputs=ROOT.TList()
 	isTree= obj.IsA().InheritsFrom(ROOT.TTree.Class())
-	if isTree :
+	if isTree:
 		obj=obj.CloneTree(-1,"fast" if goFast else "")
 		branchNames=set([x.GetName() for x in obj.GetListOfBranches()])
 	for fh in fileHandles[1:] :
@@ -51,12 +55,26 @@ for e in fileHandles[0].GetListOfKeys() :
 			additionalBranches=list(otherBranches-branchNames)
 			print "missing:",missingBranches,"\n Additional:",additionalBranches
 			for br in missingBranches :
-				#fill "Other"	
+				#fill "Other"
 				zeroFill(otherObj,br,obj.GetListOfBranches().FindObject(br))
 			for br in additionalBranches :
-				#fill main	
+				#fill main
 				branchNames.add(br)
 				zeroFill(obj,br,otherObj.GetListOfBranches().FindObject(br))
+			#merge immediately for trees
+		if isTree and obj.GetName()=='Runs':
+			otherObj.SetAutoFlush(0)
+			otherBranches=set([ x.GetName() for x in otherObj.GetListOfBranches() ])
+			missingBranches=list(branchNames-otherBranches)
+			additionalBranches=list(otherBranches-branchNames)
+			print "missing:",missingBranches,"\n Additional:",additionalBranches
+			for br in missingBranches :
+				#fill "Other"
+				zeroFill(otherObj,br,obj.GetListOfBranches().FindObject(br),allowNonBool=True)
+			for br in additionalBranches :
+				#fill main
+				branchNames.add(br)
+				zeroFill(obj,br,otherObj.GetListOfBranches().FindObject(br),allowNonBool=True)
 			#merge immediately for trees
                 if isTree:
 	        	obj.Merge(inputs,"fast" if goFast else "")

--- a/scripts/haddnano.py
+++ b/scripts/haddnano.py
@@ -1,6 +1,6 @@
 #!/bin/env python
 import ROOT
-from array import array
+import numpy
 import sys
 
 if len(sys.argv) < 3 :


### PR DESCRIPTION
Backfilling also the Run tree in both boolean and non-boolean branches.
This is needed to support multi-point signal scans (cms-nanoAOD/cmssw#398).

To be tested thoroughly