### PR TITLE
Improvements to output filtering

### DIFF
--- a/python/postprocessing/framework/output.py
+++ b/python/postprocessing/framework/output.py
@@ -85,7 +85,9 @@ class FullOutput(OutputTree):
         # then clone the input tree
         if outputbranchSelection:
             outputbranchSelection.selectBranches(inputTree)
-
+        self.outputbranchSelection = outputbranchSelection
+        self.maxEntries = maxEntries
+        self.firstEntry = firstEntry
         if fullClone:
             outputTree = inputTree.CopyTree('1', "", maxEntries if maxEntries else ROOT.TVirtualTreePlayer.kMaxEntries, firstEntry)
         else:            
@@ -124,6 +126,9 @@ class FullOutput(OutputTree):
         self._inputTree.readAllBranches()
         self._tree.Fill()
     def write(self):
+        self.outputbranchSelection.selectBranches(self._tree)
+        self._tree = self.tree().CopyTree('1', "", self.maxEntries if self.maxEntries else ROOT.TVirtualTreePlayer.kMaxEntries, self.firstEntry)
+
         OutputTree.write(self)
         for t in self._otherTrees.itervalues():
             t.Write()

--- a/python/postprocessing/modules/common/collectionMerger.py
+++ b/python/postprocessing/modules/common/collectionMerger.py
@@ -27,6 +27,7 @@ class collectionMerger(Module):
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         _brlist = inputTree.GetListOfBranches()
         branches = [_brlist.At(i) for i in xrange(_brlist.GetEntries())]
+        branches = filter(lambda x: inputTree.GetBranchStatus(x.GetName()), branches)
         self.brlist_sep = [self.filterBranchNames(branches,x) for x in self.input]
         self.brlist_all = set(itertools.chain(*(self.brlist_sep)))
 

--- a/python/postprocessing/modules/common/collectionMerger.py
+++ b/python/postprocessing/modules/common/collectionMerger.py
@@ -25,9 +25,21 @@ class collectionMerger(Module):
         pass
 
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
-        _brlist = inputTree.GetListOfBranches()
-        branches = [_brlist.At(i) for i in xrange(_brlist.GetEntries())]
-        branches = filter(lambda x: inputTree.GetBranchStatus(x.GetName()), branches)
+
+        # Find list of activated branches in input tree
+        _brlist_in = inputTree.GetListOfBranches()
+        branches_in = set([_brlist_in.At(i) for i in xrange(_brlist_in.GetEntries())])
+        branches_in = filter(lambda x: inputTree.GetBranchStatus(x.GetName()), branches_in)
+
+        # Find list of activated branches in output tree
+        _brlist_out = wrappedOutputTree._tree.GetListOfBranches()
+        branches_out = set([_brlist_out.At(i) for i in xrange(_brlist_out.GetEntries())])
+        branches_out = filter(lambda x: wrappedOutputTree._tree.GetBranchStatus(x.GetName()), branches_out)
+
+        # Use both
+        branches = branches_in + branches_out
+
+        # Only keep branches with right collection name
         self.brlist_sep = [self.filterBranchNames(branches,x) for x in self.input]
         self.brlist_all = set(itertools.chain(*(self.brlist_sep)))
 
@@ -36,6 +48,7 @@ class collectionMerger(Module):
             for j in xrange(self.nInputs):
                 if br in self.brlist_sep[j]: self.is_there[bridx][j]=True
 
+        # Create output branches
         self.out = wrappedOutputTree
         for br in self.brlist_all:
             self.out.branch("%s_%s"%(self.output,br), _rootLeafType2rootBranchType[self.branchType[br]], lenVar="n%s"%self.output)


### PR DESCRIPTION
This PR fixes three issues I have encountered when working with collection merging and output filtering:

1. the output branch selection definition is applied to `collectionMerger` output. 

2. output branch selection is applied to newly created branches. This is useful for filtering a new collection based on branches that do not exist at the beginning of the run. For example, one might want to filter jet candidates based on their JES-corrected properties.

3. `collectionMerger` correctly copies newly made branches to the new collection. Previously, it would ignore these.

An example implementation of a scenario where these three issues come into play is given [in this gist](https://gist.github.com/AndreasAlbert/d06a512534b88a812e8ea8718b8bb7bb). 