### PR TITLE
Use the correct data PU histogram for 2017

### DIFF
--- a/python/postprocessing/modules/common/puWeightProducer.py
+++ b/python/postprocessing/modules/common/puWeightProducer.py
@@ -91,7 +91,7 @@ pufile_data2016="%s/src/PhysicsTools/NanoAODTools/python/postprocessing/data/pil
 puWeight_2016 = lambda : puWeightProducer(pufile_mc2016,pufile_data2016,"pu_mc","pileup",verbose=False, doSysVar=True)
 puAutoWeight_2016 = lambda : puWeightProducer("auto", pufile_data2016,"pu_mc","pileup",verbose=False)
 
-pufile_data2017="%s/src/PhysicsTools/NanoAODTools/python/postprocessing/data/pileup/PileupHistogram-goldenJSON-13tev-2018-99bins_withVar.root" % os.environ['CMSSW_BASE']
+pufile_data2017="%s/src/PhysicsTools/NanoAODTools/python/postprocessing/data/pileup/PileupHistogram-goldenJSON-13tev-2017-99bins_withVar.root" % os.environ['CMSSW_BASE']
 pufile_mc2017="%s/src/PhysicsTools/NanoAODTools/python/postprocessing/data/pileup/mcPileup2017.root" % os.environ['CMSSW_BASE']
 puWeight_2017 = lambda : puWeightProducer(pufile_mc2017,pufile_data2017,"pu_mc","pileup",verbose=False, doSysVar=True)
 puAutoWeight_2017 = lambda : puWeightProducer("auto",pufile_data2017,"pu_mc","pileup",verbose=False)


### PR DESCRIPTION
The wrong data pileup histogram was used in the puWeightProducer for 2017.