### PR TITLE
Fix #203 in case no outputbranchSelection is defined

### DIFF
--- a/python/postprocessing/framework/output.py
+++ b/python/postprocessing/framework/output.py
@@ -126,7 +126,8 @@ class FullOutput(OutputTree):
         self._inputTree.readAllBranches()
         self._tree.Fill()
     def write(self):
-        self.outputbranchSelection.selectBranches(self._tree)
+        if self.outputbranchSelection:
+            self.outputbranchSelection.selectBranches(self._tree)
         self._tree = self.tree().CopyTree('1', "", self.maxEntries if self.maxEntries else ROOT.TVirtualTreePlayer.kMaxEntries, self.firstEntry)
 
         OutputTree.write(self)


### PR DESCRIPTION
After updating to the latest version (and picking up #203 and #218 ) I get the following error:
```bash
% nano_postproc.py -I PhysicsTools.NanoAODTools.postprocessing.modules.jme.jetmetUncertainties jetmetUncertainties2016All -I PhysicsTools.NanoAODTools.postprocessing
.modules.btv.btagSFProducer btagSF2016 --postfix=testJME . ~/bamboodev/bamboo/tests/data/DY_M50_2016.root > log
Traceback (most recent call last):                               
  File "/home/users/p/d/pdavid/bamboodev/NanoAODTools/CMSSW_11_0_0_pre4/bin/slc7_amd64_gcc700/nano_postproc.py", line 73, in <module>                                                                            
    p.run()                                                                                       
  File "/home/users/p/d/pdavid/bamboodev/NanoAODTools/CMSSW_11_0_0_pre4/python/PhysicsTools/NanoAODTools/postprocessing/framework/postprocessor.py", line 195, in run
    outTree.write()                                                                   
  File "/home/users/p/d/pdavid/bamboodev/NanoAODTools/CMSSW_11_0_0_pre4/python/PhysicsTools/NanoAODTools/postprocessing/framework/output.py", line 129, in write
    self.outputbranchSelection.selectBranches(self._tree)
AttributeError: 'NoneType' object has no attribute 'selectBranches'   
```

Adding a check if `self.outputbranchSelection` is not None before (as is done in other places) seems to fix it.