### PR TITLE
Added JMS and JMR sf for FatJet for 2018 in jetmetHelper

### DIFF
--- a/python/postprocessing/modules/jme/fatJetUncertainties.py
+++ b/python/postprocessing/modules/jme/fatJetUncertainties.py
@@ -383,11 +383,16 @@ class fatJetUncertaintiesProducer(Module):
                         jmstau21DDTDownVal = 1.007
                         jmstau21DDTUpVal = 1.021
                         self.jetSmearer.jmr_vals = [1.086,1.176,0.996]
-                    elif self.era in ["2017","2018"]:
+                    elif self.era in ["2017"]:
                         jmstau21DDTNomVal = 0.983
                         jmstau21DDTDownVal = 0.976
                         jmstau21DDTUpVal = 0.99
                         self.jetSmearer.jmr_vals = [1.080,1.161,0.999]
+                    elif self.era in ["2018"]:
+                        jmstau21DDTNomVal = 1.000   # tau21DDT < 0.43 WP
+                        jmstau21DDTDownVal = 0.990
+                        jmstau21DDTUpVal = 1.010
+                        self.jetSmearer.jmr_vals = [1.124,1.208,1.040]
 
                     ( jet_msdcorr_tau21DDT_jmrNomVal, jet_msdcorr_tau21DDT_jmrUpVal, jet_msdcorr_tau21DDT_jmrDownVal ) = self.jetSmearer.getSmearValsM(groomedP4, genGroomedJet) if groomedP4 != None and genGroomedJet != None else (0.,0.,0.)
 

--- a/python/postprocessing/modules/jme/jetmetHelperRun2.py
+++ b/python/postprocessing/modules/jme/jetmetHelperRun2.py
@@ -46,7 +46,7 @@ jerTagsMC = {'2016' : 'Summer16_25nsV1_MC',
 #nominal, up, down
 jmrValues = {'2016' : [1.0, 1.2, 0.8],
              '2017' : [1.09, 1.14, 1.04],
-             '2018' : [1.09, 1.14, 1.04]        # Use 2017 values for 2018 until 2018 are released
+             '2018' : [1.24, 1.20, 1.28]
             }
 
 #jet mass scale
@@ -54,7 +54,7 @@ jmrValues = {'2016' : [1.0, 1.2, 0.8],
 #2016 values 
 jmsValues = { '2016' : [1.00, 0.9906, 1.0094], #nominal, down, up
               '2017' : [0.982, 0.978, 0.986],
-              '2018' : [0.982, 0.978, 0.986] # Use 2017 values for 2018 until 2018 are released
+              '2018' : [0.997, 0.993, 1.001]
             }
 
 def createJMECorrector(isMC=True, dataYear=2016, runPeriod="B", jesUncert="Total", redojec=False, jetType = "AK4PFchs", noGroom=False, metBranchName="MET", applySmearing=True, isFastSim=False):


### PR DESCRIPTION
Updated 2018 JMS and JMR scale factors for FatJets from https://twiki.cern.ch/twiki/bin/view/CMS/JetWtagging