### PR TITLE
Replace time.clock() with time.time()

### DIFF
--- a/python/postprocessing/framework/eventloop.py
+++ b/python/postprocessing/framework/eventloop.py
@@ -47,7 +47,7 @@ def eventLoop(modules, inputFile, outputFile, inputTree, wrappedOutputTree, maxE
     for m in modules: 
         m.beginFile(inputFile, outputFile, inputTree, wrappedOutputTree)
 
-    t0 = time.clock(); tlast = t0; doneEvents = 0; acceptedEvents = 0
+    t0 = time.time(); tlast = t0; doneEvents = 0; acceptedEvents = 0
     entries = inputTree.entries
     if eventRange: entries = len(eventRange)
     if maxEvents > 0: entries = min(entries, maxEvents)
@@ -67,11 +67,11 @@ def eventLoop(modules, inputFile, outputFile, inputTree, wrappedOutputTree, maxE
             wrappedOutputTree.fill()
         if progress:
             if ie > 0 and ie % progress[0] == 0:
-                t1 = time.clock()
+                t1 = time.time()
                 progress[1].write("Processed %8d/%8d entries, %5.2f%% (elapsed time %7.1fs, curr speed %8.3f kHz, avg speed %8.3f kHz), accepted %8d/%8d events (%5.2f%%)\n" % (
                         ie,entries, ie/float(0.01*entries), t1-t0, (progress[0]/1000.)/(max(t1-tlast,1e-9)), ie/1000./(max(t1-t0,1e-9)), acceptedEvents, doneEvents, acceptedEvents/(0.01*doneEvents) ))
                 tlast = t1
     for m in modules: 
         m.endFile(inputFile, outputFile, inputTree, wrappedOutputTree)
 
-    return (doneEvents, acceptedEvents, time.clock() - t0)
+    return (doneEvents, acceptedEvents, time.time() - t0)


### PR DESCRIPTION
I think it is more useful to count wall time of event processing with time.time() rather than time.clock(). This would be more useful for timing comparisons.
Example: if a file served via xrootd it may take much longer to run, but the progress with time.clock() reports the CPU time as though it runs from a local machine.
