### PR TITLE
fix JER central value for METv2 recipe in 2017

### DIFF
--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -444,6 +444,9 @@ class jetmetUncertaintiesProducer(Module):
             met_py_nom += delta_y_rawJet - met_unclEE_y
             
             if not self.isData:
+              # apply v2 recipe correction factor also to JER central value and variations
+              met_px_jer += delta_x_rawJet - met_unclEE_x
+              met_py_jer += delta_y_rawJet - met_unclEE_y
               met_px_jerUp += delta_x_rawJet - met_unclEE_x
               met_py_jerUp += delta_y_rawJet - met_unclEE_y
               met_px_jerDown += delta_x_rawJet - met_unclEE_x


### PR DESCRIPTION
As pointed out in #221 the central JER smeared value of MET is not getting the v2 correction applied, which is fixed with this PR.