### PR TITLE
B-tagging scale factors: multiple working points or taggers; specify list of JEC uncertainties

### DIFF
--- a/python/postprocessing/modules/btv/btagSFProducer.py
+++ b/python/postprocessing/modules/btv/btagSFProducer.py
@@ -1,43 +1,44 @@
 import ROOT
 import os
+from itertools import chain
+
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 
 from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection
 from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
 
-def is_relevant_syst_for_shape_corr(flavor_btv, syst):
+def is_relevant_syst_for_shape_corr(flavor_btv, syst, jesSystsForShape=["jes"]):
     """Returns true if a flavor/syst combination is relevant"""
+    jesSysts = list(chain(*[ ("up_" + j, "down_" + j) for j in jesSystsForShape ]))
+
     if flavor_btv == 0:
         return syst in [ "central",
-                         "up_jes", "down_jes",
                          "up_lf", "down_lf",
                          "up_hfstats1", "down_hfstats1",
-                         "up_hfstats2", "down_hfstats2" ]
+                         "up_hfstats2", "down_hfstats2" ] + jesSysts
     elif flavor_btv == 1:
         return syst in [ "central",
                          "up_cferr1", "down_cferr1",
                          "up_cferr2", "down_cferr2" ]
     elif flavor_btv == 2:
         return syst in [ "central",
-                         "up_jes", "down_jes",
                          "up_hf", "down_hf",
                          "up_lfstats1", "down_lfstats1",
-                         "up_lfstats2", "down_lfstats2" ]
+                         "up_lfstats2", "down_lfstats2" ] + jesSysts
     else:
         raise ValueError("ERROR: Undefined flavor = %i!!" % flavor_btv)
     return True
 
 class btagSFProducer(Module):
     """Calculate btagging scale factors
-        algo has to be either 'csvv2' or 'cmva'
     """
-    def __init__(self, era, algo = 'csvv2', sfFileName = None, verbose = 0):
+    def __init__(self, era, algo='csvv2', selectedWPs=['M', 'shape_corr'], sfFileName=None, verbose=0, jesSystsForShape=["jes"]):
 
         self.era = era
-
         self.algo = algo.lower()
-
+        self.selectedWPs = selectedWPs
         self.verbose = verbose
+        self.jesSystsForShape = jesSystsForShape
 
         # CV: Return value of BTagCalibrationReader::eval_auto_bounds() is zero
         #     in case jet abs(eta) > 2.4 !!
@@ -95,8 +96,8 @@ class btagSFProducer(Module):
                         1 : "comb",  # c
                         2 : "incl"   # light
                     },
-                    'supported_wp' : [ "L", "M", "T", "shape_corr"] 
-                }    
+                    'supported_wp' : [ "L", "M", "T", "shape_corr"]
+                }
             },
             'deepjet' : {
                 'Legacy2016' : {
@@ -125,7 +126,7 @@ class btagSFProducer(Module):
                         2 : "incl"   # light
                     },
                     'supported_wp' : [ "L", "M", "T", "shape_corr"]
-                }    
+                }
             },
             'cmva' : {
                 '2016' : {
@@ -142,7 +143,7 @@ class btagSFProducer(Module):
 
         supported_algos = []
         for algo in supported_btagSF.keys():
-            if era in supported_btagSF[algo].keys():
+            if self.era in supported_btagSF[algo].keys():
                 supported_algos.append(algo)
         if self.algo in supported_btagSF.keys():
             if self.era in supported_btagSF[self.algo].keys():
@@ -154,19 +155,9 @@ class btagSFProducer(Module):
                 raise ValueError("ERROR: Algorithm '%s' not supported for era = '%s'! Please choose among { %s }." % (self.algo, self.era, supported_algos))
         else:
             raise ValueError("ERROR: Algorithm '%s' not supported for era = '%s'! Please choose among { %s }." % (self.algo, self.era, supported_algos))
-
-        algoLabel = None
-        if self.algo == "csvv2":
-            algoLabel = "CSV (v2)"
-        elif self.algo == "deepcsv":
-            algoLabel = "deep-CSV (b)"
-        elif self.algo == "cmva":
-            algoLabel = "cMVA"
-        elif self.algo == "deepjet":
-            algoLabel = "DeepJet"
-        else:
-            raise ValueError("ERROR: Algorithm '%s' not supported for era = '%s'! Please choose among { %s }." % (self.algo, self.era, supported_algos))
-        print("Loading btagSF weights for %s algorithm from file '%s'" % (algoLabel, os.path.join(self.inputFilePath, self.inputFileName)))
+        for wp in self.selectedWPs:
+            if wp not in self.supported_wp:
+                raise ValueError("ERROR: Working point '%s' not supported for algo = '%s' and era = '%s'! Please choose among { %s }." % (wp, self.algo, self.era, self.supported_wp))
 
         # load libraries for accessing b-tag scale factors (SFs) from conditions database
         for library in [ "libCondFormatsBTauObjects", "libCondToolsBTau" ]:
@@ -182,36 +173,37 @@ class btagSFProducer(Module):
         self.central_and_systs.extend(self.systs)
 
         self.systs_shape_corr = []
-        for syst in [ 'jes',
-                      'lf', 'hf',
+        for syst in [ 'lf', 'hf',
                       'hfstats1', 'hfstats2',
                       'lfstats1', 'lfstats2',
-                      'cferr1', 'cferr2' ]:
+                      'cferr1', 'cferr2' ] + self.jesSystsForShape:
             self.systs_shape_corr.append("up_%s" % syst)
             self.systs_shape_corr.append("down_%s" % syst)
         self.central_and_systs_shape_corr = [ "central" ]
         self.central_and_systs_shape_corr.extend(self.systs_shape_corr)
 
         self.branchNames_central_and_systs = {}
-        for central_or_syst in self.central_and_systs:
-            if central_or_syst == "central":
-                self.branchNames_central_and_systs[central_or_syst] = "Jet_btagSF"
+        for wp in self.selectedWPs:
+            branchNames = {}
+            if wp == 'shape_corr':
+                central_and_systs = self.central_and_systs_shape_corr
+                baseBranchName = 'Jet_btagSF_{}_shape'.format(self.algo)
             else:
-                self.branchNames_central_and_systs[central_or_syst] = "Jet_btagSF_%s" % central_or_syst
-
-        self.branchNames_central_and_systs_shape_corr = {}
-        for central_or_syst in self.central_and_systs_shape_corr:
-            if central_or_syst == "central":
-                self.branchNames_central_and_systs_shape_corr[central_or_syst] = "Jet_btagSF_shape"
-            else:
-                self.branchNames_central_and_systs_shape_corr[central_or_syst] = "Jet_btagSF_shape_%s" % central_or_syst
+                central_and_systs = self.central_and_systs
+                baseBranchName = 'Jet_btagSF_{}_{}'.format(self.algo, wp)
+            for central_or_syst in central_and_systs:
+                if central_or_syst == "central":
+                    branchNames[central_or_syst] = baseBranchName
+                else:
+                    branchNames[central_or_syst] = baseBranchName + '_' + central_or_syst
+            self.branchNames_central_and_systs[wp] = branchNames
 
     def beginJob(self):
         # initialize BTagCalibrationReader
         # (cf. https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagCalibration )
         self.calibration = ROOT.BTagCalibration(self.algo, os.path.join(self.inputFilePath, self.inputFileName))
         self.readers = {}
-        for wp in self.supported_wp:
+        for wp in self.selectedWPs:
             wp_btv = { "l" : 0, "m" : 1, "t" : 2, "shape_corr" : 3 }.get(wp.lower(), None)
             syts = None
             if wp_btv in [ 0, 1, 2 ]:
@@ -234,21 +226,18 @@ class btagSFProducer(Module):
 
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         self.out = wrappedOutputTree
-        for central_or_syst in self.central_and_systs:
-            self.out.branch(self.branchNames_central_and_systs[central_or_syst], "F", lenVar="nJet")
-        for central_or_syst in self.central_and_systs_shape_corr:
-            self.out.branch(self.branchNames_central_and_systs_shape_corr[central_or_syst], "F", lenVar="nJet")
+        for central_or_syst in self.branchNames_central_and_systs.values():
+            for branch in central_or_syst.values():
+                self.out.branch(branch, "F", lenVar="nJet")
 
     def endFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         pass
 
-    def getReader(self, wp, shape_corr = False):
+    def getReader(self, wp):
         """
             Get btag scale factor reader.
             Convert working points: input is 'L', 'M', 'T', 'shape_corr' to 0, 1, 2, 3
         """
-        if shape_corr:
-            wp = "shape_corr"
         wp_btv = { "l" : 0, "m" : 1, "t" : 2, "shape_corr" : 3 }.get(wp.lower(), None)
         if wp_btv == None or not wp_btv in self.readers.keys():
             if self.verbose > 0:
@@ -292,7 +281,7 @@ class btagSFProducer(Module):
             # evaluate SF
             sf = None
             if shape_corr:
-                if is_relevant_syst_for_shape_corr(flavor_btv, syst):
+                if is_relevant_syst_for_shape_corr(flavor_btv, syst, self.jesSystsForShape):
                     sf = reader.eval_auto_bounds(syst, flavor_btv, eta, pt, discr)
                 else:
                     sf = reader.eval_auto_bounds('central', flavor_btv, eta, pt, discr)
@@ -320,20 +309,17 @@ class btagSFProducer(Module):
         elif self.algo == "deepjet":
             discr = "btagDeepFlavB"
         else:
-            raise ValueError("ERROR: Invalid algorithm '%s'! Please choose either 'csvv2' or 'cmva'." % self.algo)
+            raise ValueError("ERROR: Invalid algorithm '%s'!" % self.algo)
 
         preloaded_jets = [(jet.pt, jet.eta, self.getFlavorBTV(jet.hadronFlavour), getattr(jet, discr)) for jet in jets]
-        reader = self.getReader('M', False)
-        for central_or_syst in self.central_and_systs:
-            central_or_syst = central_or_syst.lower()
-            scale_factors = list(self.getSFs(preloaded_jets, central_or_syst, reader, 'auto', False))
-            self.out.fillBranch(self.branchNames_central_and_systs[central_or_syst], scale_factors)
-        # shape corrections
-        reader = self.getReader('shape_corr', True)
-        for central_or_syst in self.central_and_systs_shape_corr:
-            central_or_syst = central_or_syst.lower()
-            scale_factors = list(self.getSFs(preloaded_jets, central_or_syst, reader, 'auto', True))
-            self.out.fillBranch(self.branchNames_central_and_systs_shape_corr[central_or_syst], scale_factors)
+        for wp in self.selectedWPs:
+            reader = self.getReader(wp)
+            isShape = ( wp == 'shape_corr' )
+            central_and_systs = ( self.central_and_systs_shape_corr if isShape else self.central_and_systs )
+            for central_or_syst in central_and_systs:
+                central_or_syst = central_or_syst.lower()
+                scale_factors = list(self.getSFs(preloaded_jets, central_or_syst, reader, 'auto', isShape))
+                self.out.fillBranch(self.branchNames_central_and_systs[wp][central_or_syst], scale_factors)
 
         return True
 

--- a/python/postprocessing/modules/btv/btagSFProducer.py
+++ b/python/postprocessing/modules/btv/btagSFProducer.py
@@ -317,7 +317,6 @@ class btagSFProducer(Module):
             isShape = ( wp == 'shape_corr' )
             central_and_systs = ( self.central_and_systs_shape_corr if isShape else self.central_and_systs )
             for central_or_syst in central_and_systs:
-                central_or_syst = central_or_syst.lower()
                 scale_factors = list(self.getSFs(preloaded_jets, central_or_syst, reader, 'auto', isShape))
                 self.out.fillBranch(self.branchNames_central_and_systs[wp][central_or_syst], scale_factors)
 


### PR DESCRIPTION
Currently, the `btagSFProducer` module will only add the SFs for a single working point (hardcoded to `M`). Furthermore, the naming of the branches (`Jet_btagSF`) prevents the user to add SFs for several taggers. Finally, the shape correction SFs include systematic variations that have to be correlated with the JEC variations. By default only the total uncertainty is taken into account, but in case one uses SFs which include the split (or reduced) JEC uncertainty sources, one would like to have all the corresponding SF variations stored as well. 

With this PR, the user can select all the working points he'd like (default: `['M', 'shape_corr']`), and the branches are now named as e.g. `Jet_btagSF_<tagger>_<WP>` so that several modules can be added to get the SFs for different taggers.

Also, an extra option is added to specify the list of JEC uncertainties to be considered for b-tagging shape correction SFs.