### PR TITLE
JES uncertainty fix

### DIFF
--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -510,8 +510,6 @@ class jetmetUncertaintiesProducer(Module):
           self.out.fillBranch("%s_pt_unclustEnDown" % self.metBranchName, math.sqrt(met_px_unclEnDown**2 + met_py_unclEnDown**2))
           self.out.fillBranch("%s_phi_unclustEnDown" % self.metBranchName, math.atan2(met_py_unclEnDown, met_px_unclEnDown))
 
-        print 'nano', event.MET_pt, 'raw', event.RawMET_pt, 'corr', math.sqrt(met_px_nom**2 + met_py_nom**2)
-
         return True
 
 # define modules using the syntax 'name = lambda : constructor' to avoid having them loaded when not needed


### PR DESCRIPTION
There is a discrepancy of the propagation of JES variations to type-1 MET between CMSSW and NanoAOD-tools. Discussed here:
https://indico.cern.ch/event/921037/contributions/3869620/attachments/2042217/3420993/nanoaod_jes_talk_v2.pdf
The fix was tested for 2017 (with METv2 recipe) and 2018. Consistent results up to the numerical precision of nanoAOD and the following bin migrations are now achieved.