### PR TITLE
Fixing MET collection used for applying Type1 corrections for PupiMET

### DIFF
--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -211,6 +211,8 @@ class jetmetUncertaintiesProducer(Module):
         
         met     = Object(event, self.metBranchName)
         rawmet  = Object(event, "RawMET")
+        if  "Puppi" in self.metBranchName :
+            rawmet  = Object(event, "RawPuppiMET")
         defmet  = Object(event, "MET")
 
         ( t1met_px,       t1met_py       ) = ( met.pt*math.cos(met.phi), met.pt*math.sin(met.phi) )


### PR DESCRIPTION
Re-applying Type-1 Correction for PuppiMET does not work currently since the wrong input MET collection is used (PF MET).
This PR switches the collection used to the appropriate one for PuppiMET

This is important going forward when the Puppi objects become default in the future and also for using with custom JME NanoAODs where the re-application of Type-1 corrections for PuppiMET will become useful.