### PR TITLE
Updates on T1Smear MET calculation: Central value + JME uncertainties

### DIFF
--- a/python/postprocessing/modules/jme/jetSmearer.py
+++ b/python/postprocessing/modules/jme/jetSmearer.py
@@ -72,7 +72,7 @@ class jetSmearer(Module):
         return ( jet_pt_nomVal*jet.pt, jet_pt_jerUpVal*jet.pt, jet_pt_jerDownVal*jet.pt )
         
     
-    def getSmearValsPt(self, jetIn, genJetIn, rho):
+    def getSmearValsPt(self, jetIn, genJetIn, rho, t1Smear=False):
         
         if hasattr( jetIn, "p4"):
             jet = jetIn.p4()

--- a/python/postprocessing/modules/jme/jetSmearer.py
+++ b/python/postprocessing/modules/jme/jetSmearer.py
@@ -72,7 +72,7 @@ class jetSmearer(Module):
         return ( jet_pt_nomVal*jet.pt, jet_pt_jerUpVal*jet.pt, jet_pt_jerDownVal*jet.pt )
         
     
-    def getSmearValsPt(self, jetIn, genJetIn, rho, t1Smear=False):
+    def getSmearValsPt(self, jetIn, genJetIn, rho):
         
         if hasattr( jetIn, "p4"):
             jet = jetIn.p4()

--- a/python/postprocessing/modules/jme/jetmetHelperRun2.py
+++ b/python/postprocessing/modules/jme/jetmetHelperRun2.py
@@ -100,7 +100,11 @@ def createJMECorrector(isMC=True, dataYear=2016, runPeriod="B", jesUncert="Total
 
     if 'AK4' in jetType:
       if isMC:
+<<<<<<< HEAD
           jmeCorrections = lambda : jetmetUncertaintiesProducer(era=dataYear,                      globalTag=jecTag_, jesUncertainties=jmeUncert_, jerTag=jerTag_, jetType=jetType, metBranchName=met_, applySmearing=applySmearing, applyHEMfix=applyHEMfix, splitJER=splitJER)
+=======
+          jmeCorrections = lambda : jetmetUncertaintiesProducer(era=dataYear,                      globalTag=jecTag_, jesUncertainties=jmeUncert_, jerTag=jerTag_, jetType = jetType, metBranchName=met_, applySmearing = applySmearing, useT1SmearMETforUncs=useT1SmearMETforUncs)
+>>>>>>> Add a flag to choose between T1 or T1Smear MET uncertainty calculation
       else:
           jmeCorrections = lambda : jetmetUncertaintiesProducer(era=dataYear, archive=archiveTag_, globalTag=jecTag_, jesUncertainties=jmeUncert_, jerTag=jerTag_, jetType=jetType, metBranchName=met_, isData=True)
     # no MET variations calculated

--- a/python/postprocessing/modules/jme/jetmetHelperRun2.py
+++ b/python/postprocessing/modules/jme/jetmetHelperRun2.py
@@ -69,7 +69,7 @@ jmsValues = { '2016'   : [1.00, 0.9906, 1.0094], # nominal, down, up
               'UL2017' : [1.000, 1.000, 1.000], # placeholder
             }
 
-def createJMECorrector(isMC=True, dataYear=2016, runPeriod="B", jesUncert="Total", jetType="AK4PFchs", noGroom=False, metBranchName="MET", applySmearing=True, isFastSim=False, applyHEMfix=False, splitJER=False):
+def createJMECorrector(isMC=True, dataYear=2016, runPeriod="B", jesUncert="Total", jetType="AK4PFchs", noGroom=False, metBranchName="MET", applySmearing=True, isFastSim=False, applyHEMfix=False, splitJER=False, saveMETUncs=['T1','T1Smear']):
     
     dataYear = str(dataYear)
 
@@ -100,11 +100,7 @@ def createJMECorrector(isMC=True, dataYear=2016, runPeriod="B", jesUncert="Total
 
     if 'AK4' in jetType:
       if isMC:
-<<<<<<< HEAD
-          jmeCorrections = lambda : jetmetUncertaintiesProducer(era=dataYear,                      globalTag=jecTag_, jesUncertainties=jmeUncert_, jerTag=jerTag_, jetType=jetType, metBranchName=met_, applySmearing=applySmearing, applyHEMfix=applyHEMfix, splitJER=splitJER)
-=======
-          jmeCorrections = lambda : jetmetUncertaintiesProducer(era=dataYear,                      globalTag=jecTag_, jesUncertainties=jmeUncert_, jerTag=jerTag_, jetType = jetType, metBranchName=met_, applySmearing = applySmearing, useT1SmearMETforUncs=useT1SmearMETforUncs)
->>>>>>> Add a flag to choose between T1 or T1Smear MET uncertainty calculation
+          jmeCorrections = lambda : jetmetUncertaintiesProducer(era=dataYear,                      globalTag=jecTag_, jesUncertainties=jmeUncert_, jerTag=jerTag_, jetType=jetType, metBranchName=met_, applySmearing=applySmearing, applyHEMfix=applyHEMfix, splitJER=splitJER, saveMETUncs=saveMETUncs)
       else:
           jmeCorrections = lambda : jetmetUncertaintiesProducer(era=dataYear, archive=archiveTag_, globalTag=jecTag_, jesUncertainties=jmeUncert_, jerTag=jerTag_, jetType=jetType, metBranchName=met_, isData=True)
     # no MET variations calculated

--- a/python/postprocessing/modules/jme/jetmetHelperRun2.py
+++ b/python/postprocessing/modules/jme/jetmetHelperRun2.py
@@ -48,7 +48,7 @@ jecTagsDATA = { '2016B'   : 'Summer16_07Aug2017BCD_V11_DATA',
 
 jerTagsMC = { '2016'   : 'Summer16_25nsV1_MC',
               '2017'   : 'Fall17_V3_MC',
-              '2018'   : 'Autumn18_V7b_MC'
+              '2018'   : 'Autumn18_V7b_MC',
               'UL2017' : 'Summer19UL17_JRV2_MC',
             }
 

--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -176,14 +176,23 @@ class jetmetUncertaintiesProducer(Module):
               for jerID in self.splitJERIDs:
                   self.out.branch("%s_pt_jer%s%s" % (self.jetBranchName, jerID, shift), "F", lenVar=self.lenVar)
                   self.out.branch("%s_mass_jer%s%s" % (self.jetBranchName, jerID, shift), "F", lenVar=self.lenVar)
-                  self.out.branch("%s_pt_jer%s%s" % (self.metBranchName, jerID, shift), "F")
-                  self.out.branch("%s_phi_jer%s%s" % (self.metBranchName, jerID, shift), "F")
+                  if 'T1' in self.saveMETUncs:
+                    self.out.branch("%s_T1_pt_jer%s%s" % (self.metBranchName, jerID, shift), "F")
+                    self.out.branch("%s_T1_phi_jer%s%s" % (self.metBranchName, jerID, shift), "F")
+                  if 'T1Smear' in self.saveMETUncs:
+                    self.out.branch("%s_T1Smear_pt_jer%s%s" % (self.metBranchName, jerID, shift), "F")
+                    self.out.branch("%s_T1Smear_phi_jer%s%s" % (self.metBranchName, jerID, shift), "F")
 
               for jesUncertainty in self.jesUncertainties:
                   self.out.branch("%s_pt_jes%s%s" % (self.jetBranchName, jesUncertainty, shift), "F", lenVar=self.lenVar)
                   self.out.branch("%s_mass_jes%s%s" % (self.jetBranchName, jesUncertainty, shift), "F", lenVar=self.lenVar)
-                  self.out.branch("%s_pt_jes%s%s" % (self.metBranchName, jesUncertainty, shift), "F")
-                  self.out.branch("%s_phi_jes%s%s" % (self.metBranchName, jesUncertainty, shift), "F")
+                  if 'T1' in self.saveMETUncs:
+                    self.out.branch("%s_T1_pt_jes%s%s" % (self.metBranchName, jesUncertainty, shift), "F")
+                    self.out.branch("%s_T1_phi_jes%s%s" % (self.metBranchName, jesUncertainty, shift), "F")
+                  if 'T1Smear' in self.saveMETUncs:
+                    self.out.branch("%s_T1Smear_pt_jes%s%s" % (self.metBranchName, jesUncertainty, shift), "F")
+                    self.out.branch("%s_T1Smear_phi_jes%s%s" % (self.metBranchName, jesUncertainty, shift), "F")
+
               self.out.branch("%s_pt_unclustEn%s" % (self.metBranchName, shift), "F")
               self.out.branch("%s_phi_unclustEn%s" % (self.metBranchName, shift), "F")
                         
@@ -253,28 +262,40 @@ class jetmetUncertaintiesProducer(Module):
             rawmet  = Object(event, "RawPuppiMET")
         defmet  = Object(event, "MET")
 
-        ( t1met_px,       t1met_py       ) = ( met.pt*math.cos(met.phi), met.pt*math.sin(met.phi) )
-        ( def_met_px,     def_met_py     ) = ( defmet.pt*math.cos(defmet.phi),   defmet.pt*math.sin(defmet.phi) )
-        ( met_px,         met_py         ) = ( rawmet.pt*math.cos(rawmet.phi), rawmet.pt*math.sin(rawmet.phi) )
-        ( met_px_nom,     met_py_nom     ) = ( met_px, met_py )
-        ( met_px_jer,     met_py_jer     ) = ( met_px, met_py )
+        ( t1met_px,         t1met_py        ) = ( met.pt*math.cos(met.phi), met.pt*math.sin(met.phi) )
+        ( def_met_px,       def_met_py      ) = ( defmet.pt*math.cos(defmet.phi),   defmet.pt*math.sin(defmet.phi) )
+        ( met_px,           met_py          ) = ( rawmet.pt*math.cos(rawmet.phi), rawmet.pt*math.sin(rawmet.phi) )
+        ( met_T1_px,        met_T1_py       ) = ( met_px, met_py )
+        ( met_T1Smear_px,   met_T1Smear_py  ) = ( met_px, met_py )
         
-        ( met_px_jerUp, met_px_jerDown, met_py_jerUp, met_py_jerDown ) = ( {}, {}, {}, {} )
+        if 'T1' in self.saveMETUncs:
+            ( met_T1_px_jerUp, met_T1_px_jerDown, met_T1_py_jerUp, met_T1_py_jerDown ) = ( {}, {}, {}, {} )
+        if 'T1Smear' in self.saveMETUncs:
+            ( met_T1Smear_px_jerUp, met_T1Smear_px_jerDown, met_T1Smear_py_jerUp, met_T1Smear_py_jerDown ) = ( {}, {}, {}, {} )
         for jerID in self.splitJERIDs:
-            ( met_px_jerUp[jerID],   met_py_jerUp[jerID]   ) = ( met_px, met_py )
-            ( met_px_jerDown[jerID], met_py_jerDown[jerID] ) = ( met_px, met_py )
+            if 'T1' in self.saveMETUncs:
+                ( met_T1_px_jerUp[jerID],   met_T1_py_jerUp[jerID]   ) = ( met_px, met_py )
+                ( met_T1_px_jerDown[jerID], met_T1_py_jerDown[jerID] ) = ( met_px, met_py )
+            if 'T1Smear' in self.saveMETUncs:
+                ( met_T1Smear_px_jerUp[jerID],   met_T1Smear_py_jerUp[jerID]   ) = ( met_px, met_py )
+                ( met_T1Smear_px_jerDown[jerID], met_T1Smear_py_jerDown[jerID] ) = ( met_px, met_py )
         
-        ( met_px_jesUp,   met_py_jesUp   ) = ( {}, {} )
-        ( met_px_jesDown, met_py_jesDown ) = ( {}, {} )
-        for jesUncertainty in self.jesUncertainties:
-            met_T1_px_jesUp[jesUncertainty]   = met_px
-            met_T1_py_jesUp[jesUncertainty]   = met_py
-            met_T1_px_jesDown[jesUncertainty] = met_px
-            met_T1_py_jesDown[jesUncertainty] = met_py
-            met_T1Smear_px_jesUp[jesUncertainty]   = met_px
-            met_T1Smear_py_jesUp[jesUncertainty]   = met_py
-            met_T1Smear_px_jesDown[jesUncertainty] = met_px
-            met_T1Smear_py_jesDown[jesUncertainty] = met_py
+        if 'T1' in self.saveMETUncs:
+            ( met_T1_px_jesUp,   met_T1_py_jesUp   ) = ( {}, {} )
+            ( met_T1_px_jesDown, met_T1_py_jesDown ) = ( {}, {} )
+            for jesUncertainty in self.jesUncertainties:
+                met_T1_px_jesUp[jesUncertainty]   = met_px
+                met_T1_py_jesUp[jesUncertainty]   = met_py
+                met_T1_px_jesDown[jesUncertainty] = met_px
+                met_T1_py_jesDown[jesUncertainty] = met_py
+        if 'T1Smear' in self.saveMETUncs:
+            ( met_T1Smear_px_jesUp,   met_T1Smear_py_jesUp   ) = ( {}, {} )
+            ( met_T1Smear_px_jesDown, met_T1Smear_py_jesDown ) = ( {}, {} )
+            for jesUncertainty in self.jesUncertainties:
+                met_T1Smear_px_jesUp[jesUncertainty]   = met_px
+                met_T1Smear_py_jesUp[jesUncertainty]   = met_py
+                met_T1Smear_px_jesDown[jesUncertainty] = met_px
+                met_T1Smear_py_jesDown[jesUncertainty] = met_py
 
         # variables needed for re-applying JECs to 2017 v2 MET
         delta_x_T1Jet, delta_y_T1Jet = 0, 0
@@ -369,14 +390,8 @@ class jetmetUncertaintiesProducer(Module):
             # evaluate JER scale factors and uncertainties
             # (cf. https://twiki.cern.ch/twiki/bin/view/CMS/JetResolution and https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyResolution )
             if not self.isData:
-              # Get the smearing factors for T1Smear MET correction
-              ( jet_pt_jerNomVal_T1Smear, jet_pt_jerUpVal_T1Smear, jet_pt_jerDownVal_T1Smear ) = self.jetSmearer.getSmearValsPt(jet, genJet, rho)
-              ( jet_pt_jerNomVal, jet_pt_jerUpVal, jet_pt_jerDownVal ) = ( jet_pt_jerNomVal_T1Smear, jet_pt_jerUpVal_T1Smear, jet_pt_jerDownVal_T1Smear )
-              # Get the smearing factors for jets going into T1 MET correction from the T1Smear smearing factors
-              jet_pt_jerNomVal_T1  = jet_pt_jerNomVal_T1Smear
-              jet_pt_jerUpVal_T1   = jet_pt_jerNomVal_T1
-              jet_pt_jerDownVal_T1 = 2 - jet_pt_jerNomVal_T1
-
+              # Get the smearing factors for MET correction
+              ( jet_pt_jerNomVal, jet_pt_jerUpVal, jet_pt_jerDownVal ) = self.jetSmearer.getSmearValsPt(jet, genJet, rho)
             else:
               # if you want to do something with JER in data, please add it here.
               ( jet_pt_jerNomVal, jet_pt_jerUpVal, jet_pt_jerDownVal ) = (1,1,1)
@@ -493,29 +508,44 @@ class jetmetUncertaintiesProducer(Module):
                     met_T1_px     = met_T1_px     - (jet_pt_L1L2L3  - jet_pt_L1)*jet_cosPhi 
                     met_T1_py     = met_T1_py     - (jet_pt_L1L2L3  - jet_pt_L1)*jet_sinPhi
                     if not self.isData:
-                      met_px_jer     = met_px_jer     - (jet_pt_L1L2L3*jet_pt_jerNomVal   - jet_pt_L1)*jet_cosPhi 
-                      met_py_jer     = met_py_jer     - (jet_pt_L1L2L3*jet_pt_jerNomVal   - jet_pt_L1)*jet_sinPhi 
-                      for jerID in self.splitJERIDs:
-                          jerUpVal, jerDownVal = jet_pt_jerNomVal, jet_pt_jerNomVal
-                          if jerID == self.getJERsplitID(jet_pt_nom, jet.eta):
-                              jerUpVal, jerDownVal = jet_pt_jerUpVal, jet_pt_jerDownVal
-                          met_px_jerUp[jerID]   = met_px_jerUp[jerID]   - (jet_pt_L1L2L3*jerUpVal    - jet_pt_L1)*jet_cosPhi
-                          met_py_jerUp[jerID]   = met_py_jerUp[jerID]   - (jet_pt_L1L2L3*jerUpVal    - jet_pt_L1)*jet_sinPhi
-                          met_px_jerDown[jerID] = met_px_jerDown[jerID] - (jet_pt_L1L2L3*jerDownVal  - jet_pt_L1)*jet_cosPhi
-                          met_py_jerDown[jerID] = met_py_jerDown[jerID] - (jet_pt_L1L2L3*jerDownVal  - jet_pt_L1)*jet_sinPhi
-                      for jesUncertainty in self.jesUncertainties:
-                          # Calculate JES uncertainties on unsmeared MET
-                          met_T1_px_jesUp[jesUncertainty]   = met_T1_px_jesUp[jesUncertainty]   - (jet_pt_jesUpT1[jesUncertainty]   - jet_pt_L1)*jet_cosPhi
-                          met_T1_py_jesUp[jesUncertainty]   = met_T1_py_jesUp[jesUncertainty]   - (jet_pt_jesUpT1[jesUncertainty]   - jet_pt_L1)*jet_sinPhi
-                          met_T1_px_jesDown[jesUncertainty] = met_T1_px_jesDown[jesUncertainty] - (jet_pt_jesDownT1[jesUncertainty] - jet_pt_L1)*jet_cosPhi
-                          met_T1_py_jesDown[jesUncertainty] = met_T1_py_jesDown[jesUncertainty] - (jet_pt_jesDownT1[jesUncertainty] - jet_pt_L1)*jet_sinPhi
-                          # Calculate JES uncertainties on smeared MET
-                          jesUp_correction_forT1SmearMET   =  (jet_pt_L1L2L3 - jet_pt_L1)*jet_pt_jerNomVal_T1Smear + (jet_pt_jesUpT1[jesUncertainty] - jet_pt_L1L2L3) 
-                          jesDown_correction_forT1SmearMET =  (jet_pt_L1L2L3 - jet_pt_L1)*jet_pt_jerNomVal_T1Smear + (jet_pt_jesDownT1[jesUncertainty] - jet_pt_L1L2L3) 
-                          met_T1Smear_px_jesUp[jesUncertainty]   = met_T1Smear_px_jesUp[jesUncertainty]   - jesUp_correction_forT1SmearMET*jet_cosPhi
-                          met_T1Smear_py_jesUp[jesUncertainty]   = met_T1Smear_py_jesUp[jesUncertainty]   - jesUp_correction_forT1SmearMET*jet_sinPhi
-                          met_T1Smear_px_jesDown[jesUncertainty] = met_T1Smear_px_jesDown[jesUncertainty] - jesDown_correction_forT1SmearMET*jet_cosPhi
-                          met_T1Smear_py_jesDown[jesUncertainty] = met_T1Smear_py_jesDown[jesUncertainty] - jesDown_correction_forT1SmearMET*jet_sinPhi
+                      met_T1Smear_px     = met_T1Smear_px     - (jet_pt_L1L2L3*jet_pt_jerNomVal   - jet_pt_L1)*jet_cosPhi 
+                      met_T1Smear_py     = met_T1Smear_py     - (jet_pt_L1L2L3*jet_pt_jerNomVal   - jet_pt_L1)*jet_sinPhi
+                      # Variations of T1 MET
+                      if 'T1' in self.saveMETUncs: 
+                        for jerID in self.splitJERIDs:
+                            jerUpVal, jerDownVal = jet_pt_jerNomVal, jet_pt_jerNomVal
+                            if jerID == self.getJERsplitID(jet_pt_nom, jet.eta):
+                                jerUpVal, jerDownVal = jet_pt_jerUpVal, jet_pt_jerDownVal
+                            met_T1_px_jerUp[jerID]   = met_T1_px_jerUp[jerID]   - (jet_pt_L1L2L3*jerUpVal    - jet_pt_L1)*jet_cosPhi
+                            met_T1_py_jerUp[jerID]   = met_T1_py_jerUp[jerID]   - (jet_pt_L1L2L3*jerUpVal    - jet_pt_L1)*jet_sinPhi
+                            met_T1_px_jerDown[jerID] = met_T1_px_jerDown[jerID] - (jet_pt_L1L2L3*jerDownVal  - jet_pt_L1)*jet_cosPhi
+                            met_T1_py_jerDown[jerID] = met_T1_py_jerDown[jerID] - (jet_pt_L1L2L3*jerDownVal  - jet_pt_L1)*jet_sinPhi
+                            
+                            # Calculate JES uncertainties on unsmeared MET
+                            for jesUncertainty in self.jesUncertainties:
+                                met_T1_px_jesUp[jesUncertainty]   = met_T1_px_jesUp[jesUncertainty]   - (jet_pt_jesUpT1[jesUncertainty]   - jet_pt_L1)*jet_cosPhi
+                                met_T1_py_jesUp[jesUncertainty]   = met_T1_py_jesUp[jesUncertainty]   - (jet_pt_jesUpT1[jesUncertainty]   - jet_pt_L1)*jet_sinPhi
+                                met_T1_px_jesDown[jesUncertainty] = met_T1_px_jesDown[jesUncertainty] - (jet_pt_jesDownT1[jesUncertainty] - jet_pt_L1)*jet_cosPhi
+                                met_T1_py_jesDown[jesUncertainty] = met_T1_py_jesDown[jesUncertainty] - (jet_pt_jesDownT1[jesUncertainty] - jet_pt_L1)*jet_sinPhi
+                      # Variations of T1Smear MET
+                      if 'T1Smear' in self.saveMETUncs: 
+                        for jerID in self.splitJERIDs:
+                            jerUpVal, jerDownVal = jet_pt_jerNomVal, jet_pt_jerNomVal
+                            if jerID == self.getJERsplitID(jet_pt_nom, jet.eta):
+                                jerUpVal, jerDownVal = jet_pt_jerUpVal, jet_pt_jerDownVal
+                            met_T1Smear_px_jerUp[jerID]   = met_T1Smear_px_jerUp[jerID]   - (jet_pt_L1L2L3*jerUpVal    - jet_pt_L1)*jet_cosPhi
+                            met_T1Smear_py_jerUp[jerID]   = met_T1Smear_py_jerUp[jerID]   - (jet_pt_L1L2L3*jerUpVal    - jet_pt_L1)*jet_sinPhi
+                            met_T1Smear_px_jerDown[jerID] = met_T1Smear_px_jerDown[jerID] - (jet_pt_L1L2L3*jerDownVal  - jet_pt_L1)*jet_cosPhi
+                            met_T1Smear_py_jerDown[jerID] = met_T1Smear_py_jerDown[jerID] - (jet_pt_L1L2L3*jerDownVal  - jet_pt_L1)*jet_sinPhi
+
+                            # Calculate JES uncertainties on smeared MET
+                            for jesUncertainty in self.jesUncertainties:
+                                jesUp_correction_forT1SmearMET   =  (jet_pt_L1L2L3*jet_pt_jerNomVal - jet_pt_L1) + (jet_pt_jesUpT1[jesUncertainty] - jet_pt_L1L2L3) 
+                                jesDown_correction_forT1SmearMET =  (jet_pt_L1L2L3*jet_pt_jerNomVal - jet_pt_L1) + (jet_pt_jesDownT1[jesUncertainty] - jet_pt_L1L2L3) 
+                                met_T1Smear_px_jesUp[jesUncertainty]   = met_T1Smear_px_jesUp[jesUncertainty]   - jesUp_correction_forT1SmearMET*jet_cosPhi
+                                met_T1Smear_py_jesUp[jesUncertainty]   = met_T1Smear_py_jesUp[jesUncertainty]   - jesUp_correction_forT1SmearMET*jet_sinPhi
+                                met_T1Smear_px_jesDown[jesUncertainty] = met_T1Smear_px_jesDown[jesUncertainty] - jesDown_correction_forT1SmearMET*jet_cosPhi
+                                met_T1Smear_py_jesDown[jesUncertainty] = met_T1Smear_py_jesDown[jesUncertainty] - jesDown_correction_forT1SmearMET*jet_sinPhi
 
 
         # propagate "unclustered energy" uncertainty to MET
@@ -534,26 +564,34 @@ class jetmetUncertaintiesProducer(Module):
             
             if not self.isData:
               # apply v2 recipe correction factor also to JER central value and variations
-              met_px_jer += delta_x_rawJet - met_unclEE_x
-              met_py_jer += delta_y_rawJet - met_unclEE_y
+              met_T1Smear_px += delta_x_rawJet - met_unclEE_x
+              met_T1Smear_py += delta_y_rawJet - met_unclEE_y
               
-              for jerID in self.splitJERIDs:
-                  met_px_jerUp[jerID] += delta_x_rawJet - met_unclEE_x
-                  met_py_jerUp[jerID] += delta_y_rawJet - met_unclEE_y
-                  met_px_jerDown[jerID] += delta_x_rawJet - met_unclEE_x
-                  met_py_jerDown[jerID] += delta_y_rawJet - met_unclEE_y
-              
-              for jesUncertainty in self.jesUncertainties:
-                  met_T1_px_jesUp[jesUncertainty] += delta_x_rawJet - met_unclEE_x
-                  met_T1_py_jesUp[jesUncertainty] += delta_y_rawJet - met_unclEE_y
-                  met_T1_px_jesDown[jesUncertainty] += delta_x_rawJet - met_unclEE_x
-                  met_T1_py_jesDown[jesUncertainty] += delta_y_rawJet - met_unclEE_y
+            if 'T1' in self.saveMETUncs:
+                for jerID in self.splitJERIDs:
+                    met_T1_px_jerUp[jerID] += delta_x_rawJet - met_unclEE_x
+                    met_T1_py_jerUp[jerID] += delta_y_rawJet - met_unclEE_y
+                    met_T1_px_jerDown[jerID] += delta_x_rawJet - met_unclEE_x
+                    met_T1_py_jerDown[jerID] += delta_y_rawJet - met_unclEE_y
+                  
+                for jesUncertainty in self.jesUncertainties:
+                    met_T1_px_jesUp[jesUncertainty] += delta_x_rawJet - met_unclEE_x
+                    met_T1_py_jesUp[jesUncertainty] += delta_y_rawJet - met_unclEE_y
+                    met_T1_px_jesDown[jesUncertainty] += delta_x_rawJet - met_unclEE_x
+                    met_T1_py_jesDown[jesUncertainty] += delta_y_rawJet - met_unclEE_y
 
-                  met_T1Smear_px_jesUp[jesUncertainty] += delta_x_rawJet - met_unclEE_x
-                  met_T1Smear_py_jesUp[jesUncertainty] += delta_y_rawJet - met_unclEE_y
-                  met_T1Smear_px_jesDown[jesUncertainty] += delta_x_rawJet - met_unclEE_x
-                  met_T1Smear_py_jesDown[jesUncertainty] += delta_y_rawJet - met_unclEE_y
+            if 'T1Smear' in self.saveMETUncs:
+                for jerID in self.splitJERIDs:
+                    met_T1Smear_px_jerUp[jerID] += delta_x_rawJet - met_unclEE_x
+                    met_T1Smear_py_jerUp[jerID] += delta_y_rawJet - met_unclEE_y
+                    met_T1Smear_px_jerDown[jerID] += delta_x_rawJet - met_unclEE_x
+                    met_T1Smear_py_jerDown[jerID] += delta_y_rawJet - met_unclEE_y
 
+                for jesUncertainty in self.jesUncertainties:
+                    met_T1Smear_px_jesUp[jesUncertainty] += delta_x_rawJet - met_unclEE_x
+                    met_T1Smear_py_jesUp[jesUncertainty] += delta_y_rawJet - met_unclEE_y
+                    met_T1Smear_px_jesDown[jesUncertainty] += delta_x_rawJet - met_unclEE_x
+                    met_T1Smear_py_jesDown[jesUncertainty] += delta_y_rawJet - met_unclEE_y
 
         if not self.isData:
           ( met_px_unclEnUp,   met_py_unclEnUp   ) = ( met_T1_px, met_T1_py )
@@ -574,9 +612,13 @@ class jetmetUncertaintiesProducer(Module):
             for jerID in self.splitJERIDs:
                 self.out.fillBranch("%s_pt_jer%sUp" % (self.jetBranchName, jerID), jets_pt_jerUp[jerID])
                 self.out.fillBranch("%s_pt_jer%sDown" % (self.jetBranchName, jerID), jets_pt_jerDown[jerID])
-            
-        self.out.fillBranch("%s_T1_pt" % self.metBranchName, math.sqrt(met_T1_px**2 + met_T1_py**2))
-        self.out.fillBranch("%s_T1_phi" % self.metBranchName, math.atan2(met_T1_py, met_T1_px))        
+        
+        if 'T1' in self.saveMETUncs:
+            self.out.fillBranch("%s_T1_pt" % self.metBranchName, math.sqrt(met_T1_px**2 + met_T1_py**2))
+            self.out.fillBranch("%s_T1_phi" % self.metBranchName, math.atan2(met_T1_py, met_T1_px))        
+        if 'T1Smear' in self.saveMETUncs:
+            self.out.fillBranch("%s_T1Smear_pt" % self.metBranchName, math.sqrt(met_T1_px**2 + met_T1_py**2))
+            self.out.fillBranch("%s_T1Smear_phi" % self.metBranchName, math.atan2(met_T1_py, met_T1_px))        
 
         self.out.fillBranch("%s_mass_raw" % self.jetBranchName, jets_mass_raw)
         self.out.fillBranch("%s_mass_nom" % self.jetBranchName, jets_mass_nom)
@@ -588,14 +630,22 @@ class jetmetUncertaintiesProducer(Module):
 
 
         if not self.isData:
-          self.out.fillBranch("%s_pt_jer" % self.metBranchName, math.sqrt(met_px_jer**2 + met_py_jer**2))
-          self.out.fillBranch("%s_phi_jer" % self.metBranchName, math.atan2(met_py_jer, met_px_jer))        
+          self.out.fillBranch("%s_T1Smear_pt" % self.metBranchName, math.sqrt(met_T1Smear_px**2 + met_T1Smear_py**2))
+          self.out.fillBranch("%s_T1Smear_phi" % self.metBranchName, math.atan2(met_T1Smear_py, met_T1Smear_px))        
 
-          for jerID in self.splitJERIDs:
-              self.out.fillBranch("%s_pt_jer%sUp" % (self.metBranchName, jerID), math.sqrt(met_px_jerUp[jerID]**2 + met_py_jerUp[jerID]**2))
-              self.out.fillBranch("%s_phi_jer%sUp" % (self.metBranchName, jerID), math.atan2(met_py_jerUp[jerID], met_px_jerUp[jerID]))        
-              self.out.fillBranch("%s_pt_jer%sDown" % (self.metBranchName, jerID), math.sqrt(met_px_jerDown[jerID]**2 + met_py_jerDown[jerID]**2))
-              self.out.fillBranch("%s_phi_jer%sDown" % (self.metBranchName, jerID), math.atan2(met_py_jerDown[jerID], met_px_jerDown[jerID]))
+          if 'T1' in self.saveMETUncs:
+            for jerID in self.splitJERIDs:
+                self.out.fillBranch("%s_T1_pt_jer%sUp" % (self.metBranchName, jerID), math.sqrt(met_T1_px_jerUp[jerID]**2 + met_T1_py_jerUp[jerID]**2))
+                self.out.fillBranch("%s_T1_phi_jer%sUp" % (self.metBranchName, jerID), math.atan2(met_T1_py_jerUp[jerID], met_T1_px_jerUp[jerID]))        
+                self.out.fillBranch("%s_T1_pt_jer%sDown" % (self.metBranchName, jerID), math.sqrt(met_T1_px_jerDown[jerID]**2 + met_T1_py_jerDown[jerID]**2))
+                self.out.fillBranch("%s_T1_phi_jer%sDown" % (self.metBranchName, jerID), math.atan2(met_T1_py_jerDown[jerID], met_T1_px_jerDown[jerID]))
+              
+          if 'T1Smear' in self.saveMETUncs:
+            for jerID in self.splitJERIDs:
+                self.out.fillBranch("%s_T1Smear_pt_jer%sUp" % (self.metBranchName, jerID), math.sqrt(met_T1Smear_px_jerUp[jerID]**2 + met_T1Smear_py_jerUp[jerID]**2))
+                self.out.fillBranch("%s_T1Smear_phi_jer%sUp" % (self.metBranchName, jerID), math.atan2(met_T1Smear_py_jerUp[jerID], met_T1Smear_px_jerUp[jerID]))        
+                self.out.fillBranch("%s_T1Smear_pt_jer%sDown" % (self.metBranchName, jerID), math.sqrt(met_T1Smear_px_jerDown[jerID]**2 + met_T1Smear_py_jerDown[jerID]**2))
+                self.out.fillBranch("%s_T1Smear_phi_jer%sDown" % (self.metBranchName, jerID), math.atan2(met_T1Smear_py_jerDown[jerID], met_T1Smear_px_jerDown[jerID]))
               
           for jesUncertainty in self.jesUncertainties:
               self.out.fillBranch("%s_pt_jes%sUp" % (self.jetBranchName, jesUncertainty), jets_pt_jesUp[jesUncertainty])

--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -369,11 +369,10 @@ class jetmetUncertaintiesProducer(Module):
             # evaluate JER scale factors and uncertainties
             # (cf. https://twiki.cern.ch/twiki/bin/view/CMS/JetResolution and https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyResolution )
             if not self.isData:
-            #   ( jet_pt_jerNomVal_T1, jet_pt_jerUpVal_T1, jet_pt_jerDownVal_T1 ) = self.jetSmearer.getSmearValsPt(jet, genJet, rho)
               # Get the smearing factors for T1Smear MET correction
               ( jet_pt_jerNomVal_T1Smear, jet_pt_jerUpVal_T1Smear, jet_pt_jerDownVal_T1Smear ) = self.jetSmearer.getSmearValsPt(jet, genJet, rho)
               ( jet_pt_jerNomVal, jet_pt_jerUpVal, jet_pt_jerDownVal ) = ( jet_pt_jerNomVal_T1Smear, jet_pt_jerUpVal_T1Smear, jet_pt_jerDownVal_T1Smear )
-              # Get the smearing factors for T1 MET correction from the T1Smear smearing factors
+              # Get the smearing factors for jets going into T1 MET correction from the T1Smear smearing factors
               jet_pt_jerNomVal_T1  = jet_pt_jerNomVal_T1Smear
               jet_pt_jerUpVal_T1   = jet_pt_jerNomVal_T1
               jet_pt_jerDownVal_T1 = 2 - jet_pt_jerNomVal_T1

--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -369,11 +369,15 @@ class jetmetUncertaintiesProducer(Module):
             # evaluate JER scale factors and uncertainties
             # (cf. https://twiki.cern.ch/twiki/bin/view/CMS/JetResolution and https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyResolution )
             if not self.isData:
-              # Get the smearing factors for T1 MET correction
-              ( jet_pt_jerNomVal_T1, jet_pt_jerUpVal_T1, jet_pt_jerDownVal_T1 ) = self.jetSmearer.getSmearValsPt(jet, genJet, rho)
+            #   ( jet_pt_jerNomVal_T1, jet_pt_jerUpVal_T1, jet_pt_jerDownVal_T1 ) = self.jetSmearer.getSmearValsPt(jet, genJet, rho)
               # Get the smearing factors for T1Smear MET correction
-              ( jet_pt_jerNomVal_T1Smear, jet_pt_jerUpVal_T1Smear, jet_pt_jerDownVal_T1Smear ) = self.jetSmearer.getSmearValsPt(jet, genJet, rho, t1Smear=True)
+              ( jet_pt_jerNomVal_T1Smear, jet_pt_jerUpVal_T1Smear, jet_pt_jerDownVal_T1Smear ) = self.jetSmearer.getSmearValsPt(jet, genJet, rho)
               ( jet_pt_jerNomVal, jet_pt_jerUpVal, jet_pt_jerDownVal ) = ( jet_pt_jerNomVal_T1Smear, jet_pt_jerUpVal_T1Smear, jet_pt_jerDownVal_T1Smear )
+              # Get the smearing factors for T1 MET correction from the T1Smear smearing factors
+              jet_pt_jerNomVal_T1  = jet_pt_jerNomVal_T1Smear
+              jet_pt_jerUpVal_T1   = jet_pt_jerNomVal_T1
+              jet_pt_jerDownVal_T1 = 2 - jet_pt_jerNomVal_T1
+
             else:
               # if you want to do something with JER in data, please add it here.
               ( jet_pt_jerNomVal, jet_pt_jerUpVal, jet_pt_jerDownVal ) = (1,1,1)

--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -612,12 +612,8 @@ class jetmetUncertaintiesProducer(Module):
                 self.out.fillBranch("%s_pt_jer%sUp" % (self.jetBranchName, jerID), jets_pt_jerUp[jerID])
                 self.out.fillBranch("%s_pt_jer%sDown" % (self.jetBranchName, jerID), jets_pt_jerDown[jerID])
         
-        if 'T1' in self.saveMETUncs:
-            self.out.fillBranch("%s_T1_pt" % self.metBranchName, math.sqrt(met_T1_px**2 + met_T1_py**2))
-            self.out.fillBranch("%s_T1_phi" % self.metBranchName, math.atan2(met_T1_py, met_T1_px))        
-        if 'T1Smear' in self.saveMETUncs:
-            self.out.fillBranch("%s_T1Smear_pt" % self.metBranchName, math.sqrt(met_T1_px**2 + met_T1_py**2))
-            self.out.fillBranch("%s_T1Smear_phi" % self.metBranchName, math.atan2(met_T1_py, met_T1_px))        
+        self.out.fillBranch("%s_T1_pt" % self.metBranchName, math.sqrt(met_T1_px**2 + met_T1_py**2))
+        self.out.fillBranch("%s_T1_phi" % self.metBranchName, math.atan2(met_T1_py, met_T1_px))        
 
         self.out.fillBranch("%s_mass_raw" % self.jetBranchName, jets_mass_raw)
         self.out.fillBranch("%s_mass_nom" % self.jetBranchName, jets_mass_nom)

--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -11,7 +11,7 @@ from PhysicsTools.NanoAODTools.postprocessing.modules.jme.jetSmearer import jetS
 from PhysicsTools.NanoAODTools.postprocessing.modules.jme.JetReCalibrator import JetReCalibrator
 
 class jetmetUncertaintiesProducer(Module):
-    def __init__(self, era, globalTag, jesUncertainties = [ "Total" ], archive=None, globalTagProd=None, jetType = "AK4PFchs", metBranchName="MET", jerTag="", isData=False, applySmearing=True, applyHEMfix=False, splitJER=False):
+    def __init__(self, era, globalTag, jesUncertainties = [ "Total" ], archive=None, globalTagProd=None, jetType = "AK4PFchs", metBranchName="MET", jerTag="", isData=False, applySmearing=True, applyHEMfix=False, splitJER=False, saveMETUncs=['T1','T1Smear']):
 
         # globalTagProd only needs to be defined if METFixEE2017 is to be recorrected, and should be the GT that was used for the production of the nanoAOD files
         self.era = era
@@ -35,7 +35,7 @@ class jetmetUncertaintiesProducer(Module):
 
         # Calculate and save uncertainties on T1Smear MET if this flag is set to True
         # Otherwise calculate and save uncertainties on T1 MET
-        self.useT1SmearMETforUncs = useT1SmearMETforUncs
+        self.saveMETUncs = saveMETUncs
 
         # smear jet pT to account for measured difference in JER between data and simulation.
         if jerTag != "":
@@ -601,13 +601,13 @@ class jetmetUncertaintiesProducer(Module):
               self.out.fillBranch("%s_pt_jes%sUp" % (self.jetBranchName, jesUncertainty), jets_pt_jesUp[jesUncertainty])
               self.out.fillBranch("%s_pt_jes%sDown" % (self.jetBranchName, jesUncertainty), jets_pt_jesDown[jesUncertainty])
               
-              if not self.useT1SmearMETforUncs:
+              if 'T1' in self.saveMETUncs:
                   self.out.fillBranch("%s_T1_pt_jes%sUp" % (self.metBranchName, jesUncertainty), math.sqrt(met_T1_px_jesUp[jesUncertainty]**2 + met_T1_py_jesUp[jesUncertainty]**2))
                   self.out.fillBranch("%s_T1_phi_jes%sUp" % (self.metBranchName, jesUncertainty), math.atan2(met_T1_py_jesUp[jesUncertainty], met_T1_px_jesUp[jesUncertainty]))
                   self.out.fillBranch("%s_T1_pt_jes%sDown" % (self.metBranchName, jesUncertainty), math.sqrt(met_T1_px_jesDown[jesUncertainty]**2 + met_T1_py_jesDown[jesUncertainty]**2))
                   self.out.fillBranch("%s_T1_phi_jes%sDown" % (self.metBranchName, jesUncertainty), math.atan2(met_T1_py_jesDown[jesUncertainty], met_T1_px_jesDown[jesUncertainty]))
 
-              else:
+              if 'T1Smear' in self.saveMETUncs:
                   self.out.fillBranch("%s_T1Smear_pt_jes%sUp" % (self.metBranchName, jesUncertainty), math.sqrt(met_T1Smear_px_jesUp[jesUncertainty]**2 + met_T1Smear_py_jesUp[jesUncertainty]**2))
                   self.out.fillBranch("%s_T1Smear_phi_jes%sUp" % (self.metBranchName, jesUncertainty), math.atan2(met_T1Smear_py_jesUp[jesUncertainty], met_T1Smear_px_jesUp[jesUncertainty]))
                   self.out.fillBranch("%s_T1Smear_pt_jes%sDown" % (self.metBranchName, jesUncertainty), math.sqrt(met_T1Smear_px_jesDown[jesUncertainty]**2 + met_T1Smear_py_jesDown[jesUncertainty]**2))

--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -369,7 +369,7 @@ class jetmetUncertaintiesProducer(Module):
               ( jet_pt_jerNomVal_T1, jet_pt_jerUpVal_T1, jet_pt_jerDownVal_T1 ) = self.jetSmearer.getSmearValsPt(jet, genJet, rho)
               
               # Get the smearing factors for T1Smear MET correction
-              ( jet_pt_jerNomVal_T1Smear, jet_pt_jerUpVal_T1Smear, jet_pt_jerDownVal_T1Smear) = self.jetSmearer.getSmearValsPt(jet, genJet, rho, t1smear=True)
+              ( jet_pt_jerNomVal_T1Smear, jet_pt_jerUpVal_T1Smear, jet_pt_jerDownVal_T1Smear) = self.jetSmearer.getSmearValsPt(jet, genJet, rho, t1Smear=True)
               ( jet_pt_jerNomVal, jet_pt_jerUpVal, jet_pt_jerDownVal ) = ( jet_pt_jerNomVal_T1Smear, jet_pt_jerUpVal_T1Smear, jet_pt_jerDownVal_T1Smear )
             else:
               # if you want to do something with JER in data, please add it here.

--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -504,10 +504,12 @@ class jetmetUncertaintiesProducer(Module):
                           met_T1_px_jesDown[jesUncertainty] = met_T1_px_jesDown[jesUncertainty] - (jet_pt_jesDownT1[jesUncertainty] - jet_pt_L1)*jet_cosPhi
                           met_T1_py_jesDown[jesUncertainty] = met_T1_py_jesDown[jesUncertainty] - (jet_pt_jesDownT1[jesUncertainty] - jet_pt_L1)*jet_sinPhi
                           # Calculate JES uncertainties on smeared MET
-                          met_T1Smear_px_jesUp[jesUncertainty]   = met_T1Smear_px_jesUp[jesUncertainty]   - (jet_pt_jesUpT1[jesUncertainty]   - jet_pt_L1)*jet_pt_jerNomVal_T1Smear*jet_cosPhi
-                          met_T1Smear_py_jesUp[jesUncertainty]   = met_T1Smear_py_jesUp[jesUncertainty]   - (jet_pt_jesUpT1[jesUncertainty]   - jet_pt_L1)*jet_pt_jerNomVal_T1Smear*jet_sinPhi
-                          met_T1Smear_px_jesDown[jesUncertainty] = met_T1Smear_px_jesDown[jesUncertainty] - (jet_pt_jesDownT1[jesUncertainty] - jet_pt_L1)*jet_pt_jerNomVal_T1Smear*jet_cosPhi
-                          met_T1Smear_py_jesDown[jesUncertainty] = met_T1Smear_py_jesDown[jesUncertainty] - (jet_pt_jesDownT1[jesUncertainty] - jet_pt_L1)*jet_pt_jerNomVal_T1Smear*jet_sinPhi
+                          jesUp_correction_forT1SmearMET   =  (jet_pt_L1L2L3 - jet_pt_L1)*jet_pt_jerNomVal_T1Smear + (jet_pt_jesUpT1[jesUncertainty] - jet_pt_L1L2L3) 
+                          jesDown_correction_forT1SmearMET =  (jet_pt_L1L2L3 - jet_pt_L1)*jet_pt_jerNomVal_T1Smear + (jet_pt_jesDownT1[jesUncertainty] - jet_pt_L1L2L3) 
+                          met_T1Smear_px_jesUp[jesUncertainty]   = met_T1Smear_px_jesUp[jesUncertainty]   - jesUp_correction_forT1SmearMET*jet_cosPhi
+                          met_T1Smear_py_jesUp[jesUncertainty]   = met_T1Smear_py_jesUp[jesUncertainty]   - jesUp_correction_forT1SmearMET*jet_sinPhi
+                          met_T1Smear_px_jesDown[jesUncertainty] = met_T1Smear_px_jesDown[jesUncertainty] - jesDown_correction_forT1SmearMET*jet_cosPhi
+                          met_T1Smear_py_jesDown[jesUncertainty] = met_T1Smear_py_jesDown[jesUncertainty] - jesDown_correction_forT1SmearMET*jet_sinPhi
 
 
         # propagate "unclustered energy" uncertainty to MET

--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -161,12 +161,12 @@ class jetmetUncertaintiesProducer(Module):
         self.out.branch("%s_corr_JEC" % self.jetBranchName, "F", lenVar=self.lenVar)
         self.out.branch("%s_corr_JER" % self.jetBranchName, "F", lenVar=self.lenVar)
 
-        self.out.branch("%s_pt_nom" % self.metBranchName, "F")
-        self.out.branch("%s_phi_nom" % self.metBranchName, "F")
+        self.out.branch("%s_T1_pt" % self.metBranchName, "F")
+        self.out.branch("%s_T1_phi" % self.metBranchName, "F")
 
         if not self.isData:
-          self.out.branch("%s_pt_jer" % self.metBranchName, "F")
-          self.out.branch("%s_phi_jer" % self.metBranchName, "F")
+          self.out.branch("%s_T1Smear_pt" % self.metBranchName, "F")
+          self.out.branch("%s_T1Smear_phi" % self.metBranchName, "F")
         
           for shift in [ "Up", "Down" ]:
               for jerID in self.splitJERIDs:
@@ -263,10 +263,14 @@ class jetmetUncertaintiesProducer(Module):
         ( met_px_jesUp,   met_py_jesUp   ) = ( {}, {} )
         ( met_px_jesDown, met_py_jesDown ) = ( {}, {} )
         for jesUncertainty in self.jesUncertainties:
-            met_px_jesUp[jesUncertainty]   = met_px
-            met_py_jesUp[jesUncertainty]   = met_py
-            met_px_jesDown[jesUncertainty] = met_px
-            met_py_jesDown[jesUncertainty] = met_py
+            met_T1_px_jesUp[jesUncertainty]   = met_px
+            met_T1_py_jesUp[jesUncertainty]   = met_py
+            met_T1_px_jesDown[jesUncertainty] = met_px
+            met_T1_py_jesDown[jesUncertainty] = met_py
+            met_T1Smear_px_jesUp[jesUncertainty]   = met_px
+            met_T1Smear_py_jesUp[jesUncertainty]   = met_py
+            met_T1Smear_px_jesDown[jesUncertainty] = met_px
+            met_T1Smear_py_jesDown[jesUncertainty] = met_py
 
         # variables needed for re-applying JECs to 2017 v2 MET
         delta_x_T1Jet, delta_y_T1Jet = 0, 0
@@ -475,8 +479,8 @@ class jetmetUncertaintiesProducer(Module):
                 if not ( self.metBranchName == 'METFixEE2017' and 2.65<abs(jet.eta)<3.14 and jet.pt*(1-jet.rawFactor)<50 ): # do not re-correct for jets that aren't included in METv2 recipe
                     jet_cosPhi = math.cos(jet.phi)
                     jet_sinPhi = math.sin(jet.phi)
-                    met_px_nom     = met_px_nom     - (jet_pt_L1L2L3  - jet_pt_L1)*jet_cosPhi 
-                    met_py_nom     = met_py_nom     - (jet_pt_L1L2L3  - jet_pt_L1)*jet_sinPhi
+                    met_T1_px     = met_T1_px     - (jet_pt_L1L2L3  - jet_pt_L1)*jet_cosPhi 
+                    met_T1_py     = met_T1_py     - (jet_pt_L1L2L3  - jet_pt_L1)*jet_sinPhi
                     if not self.isData:
                       met_px_jer     = met_px_jer     - (jet_pt_L1L2L3*jet_pt_jerNomVal   - jet_pt_L1)*jet_cosPhi 
                       met_py_jer     = met_py_jer     - (jet_pt_L1L2L3*jet_pt_jerNomVal   - jet_pt_L1)*jet_sinPhi 
@@ -489,10 +493,16 @@ class jetmetUncertaintiesProducer(Module):
                           met_px_jerDown[jerID] = met_px_jerDown[jerID] - (jet_pt_L1L2L3*jerDownVal  - jet_pt_L1)*jet_cosPhi
                           met_py_jerDown[jerID] = met_py_jerDown[jerID] - (jet_pt_L1L2L3*jerDownVal  - jet_pt_L1)*jet_sinPhi
                       for jesUncertainty in self.jesUncertainties:
-                          met_px_jesUp[jesUncertainty]   = met_px_jesUp[jesUncertainty]   - (jet_pt_jesUpT1[jesUncertainty]   - jet_pt_L1)*jet_cosPhi
-                          met_py_jesUp[jesUncertainty]   = met_py_jesUp[jesUncertainty]   - (jet_pt_jesUpT1[jesUncertainty]   - jet_pt_L1)*jet_sinPhi
-                          met_px_jesDown[jesUncertainty] = met_px_jesDown[jesUncertainty] - (jet_pt_jesDownT1[jesUncertainty] - jet_pt_L1)*jet_cosPhi
-                          met_py_jesDown[jesUncertainty] = met_py_jesDown[jesUncertainty] - (jet_pt_jesDownT1[jesUncertainty] - jet_pt_L1)*jet_sinPhi
+                          # Calculate JES uncertainties on unsmeared MET
+                          met_T1_px_jesUp[jesUncertainty]   = met_T1_px_jesUp[jesUncertainty]   - (jet_pt_jesUpT1[jesUncertainty]   - jet_pt_L1)*jet_cosPhi
+                          met_T1_py_jesUp[jesUncertainty]   = met_T1_py_jesUp[jesUncertainty]   - (jet_pt_jesUpT1[jesUncertainty]   - jet_pt_L1)*jet_sinPhi
+                          met_T1_px_jesDown[jesUncertainty] = met_T1_px_jesDown[jesUncertainty] - (jet_pt_jesDownT1[jesUncertainty] - jet_pt_L1)*jet_cosPhi
+                          met_T1_py_jesDown[jesUncertainty] = met_T1_py_jesDown[jesUncertainty] - (jet_pt_jesDownT1[jesUncertainty] - jet_pt_L1)*jet_sinPhi
+                          # Calculate JES uncertainties on smeared MET
+                          met_T1Smear_px_jesUp[jesUncertainty]   = met_T1Smear_px_jesUp[jesUncertainty]   - (jet_pt_jesUpT1[jesUncertainty]   - jet_pt_L1)*jet_pt_jerNomVal*jet_cosPhi
+                          met_T1Smear_py_jesUp[jesUncertainty]   = met_T1Smear_py_jesUp[jesUncertainty]   - (jet_pt_jesUpT1[jesUncertainty]   - jet_pt_L1)*jet_pt_jerNomVal*jet_sinPhi
+                          met_T1Smear_px_jesDown[jesUncertainty] = met_T1Smear_px_jesDown[jesUncertainty] - (jet_pt_jesDownT1[jesUncertainty] - jet_pt_L1)*jet_pt_jerNomVal*jet_cosPhi
+                          met_T1Smear_py_jesDown[jesUncertainty] = met_T1Smear_py_jesDown[jesUncertainty] - (jet_pt_jesDownT1[jesUncertainty] - jet_pt_L1)*jet_pt_jerNomVal*jet_sinPhi
 
 
         # propagate "unclustered energy" uncertainty to MET
@@ -506,8 +516,8 @@ class jetmetUncertaintiesProducer(Module):
             met_unclEE_y = def_met_py - t1met_py
 
             # finalize the v2 recipe for the rawMET by removing the unclustered part in the EE region
-            met_px_nom += delta_x_rawJet - met_unclEE_x 
-            met_py_nom += delta_y_rawJet - met_unclEE_y
+            met_T1_px += delta_x_rawJet - met_unclEE_x 
+            met_T1_py += delta_y_rawJet - met_unclEE_y
             
             if not self.isData:
               # apply v2 recipe correction factor also to JER central value and variations
@@ -521,15 +531,20 @@ class jetmetUncertaintiesProducer(Module):
                   met_py_jerDown[jerID] += delta_y_rawJet - met_unclEE_y
               
               for jesUncertainty in self.jesUncertainties:
-                  met_px_jesUp[jesUncertainty] += delta_x_rawJet - met_unclEE_x
-                  met_py_jesUp[jesUncertainty] += delta_y_rawJet - met_unclEE_y
-                  met_px_jesDown[jesUncertainty] += delta_x_rawJet - met_unclEE_x
-                  met_py_jesDown[jesUncertainty] += delta_y_rawJet - met_unclEE_y
+                  met_T1_px_jesUp[jesUncertainty] += delta_x_rawJet - met_unclEE_x
+                  met_T1_py_jesUp[jesUncertainty] += delta_y_rawJet - met_unclEE_y
+                  met_T1_px_jesDown[jesUncertainty] += delta_x_rawJet - met_unclEE_x
+                  met_T1_py_jesDown[jesUncertainty] += delta_y_rawJet - met_unclEE_y
+
+                  met_T1Smear_px_jesUp[jesUncertainty] += delta_x_rawJet - met_unclEE_x
+                  met_T1Smear_py_jesUp[jesUncertainty] += delta_y_rawJet - met_unclEE_y
+                  met_T1Smear_px_jesDown[jesUncertainty] += delta_x_rawJet - met_unclEE_x
+                  met_T1Smear_py_jesDown[jesUncertainty] += delta_y_rawJet - met_unclEE_y
 
 
         if not self.isData:
-          ( met_px_unclEnUp,   met_py_unclEnUp   ) = ( met_px_nom, met_py_nom )
-          ( met_px_unclEnDown, met_py_unclEnDown ) = ( met_px_nom, met_py_nom )
+          ( met_px_unclEnUp,   met_py_unclEnUp   ) = ( met_T1_px, met_T1_py )
+          ( met_px_unclEnDown, met_py_unclEnDown ) = ( met_T1_px, met_T1_py )
           met_deltaPx_unclEn = getattr(event, self.metBranchName + "_MetUnclustEnUpDeltaX")
           met_deltaPy_unclEn = getattr(event, self.metBranchName + "_MetUnclustEnUpDeltaY")
           met_px_unclEnUp    = met_px_unclEnUp   + met_deltaPx_unclEn
@@ -547,8 +562,8 @@ class jetmetUncertaintiesProducer(Module):
                 self.out.fillBranch("%s_pt_jer%sUp" % (self.jetBranchName, jerID), jets_pt_jerUp[jerID])
                 self.out.fillBranch("%s_pt_jer%sDown" % (self.jetBranchName, jerID), jets_pt_jerDown[jerID])
             
-        self.out.fillBranch("%s_pt_nom" % self.metBranchName, math.sqrt(met_px_nom**2 + met_py_nom**2))
-        self.out.fillBranch("%s_phi_nom" % self.metBranchName, math.atan2(met_py_nom, met_px_nom))        
+        self.out.fillBranch("%s_T1_pt" % self.metBranchName, math.sqrt(met_T1_px**2 + met_T1_py**2))
+        self.out.fillBranch("%s_T1_phi" % self.metBranchName, math.atan2(met_T1_py, met_T1_px))        
 
         self.out.fillBranch("%s_mass_raw" % self.jetBranchName, jets_mass_raw)
         self.out.fillBranch("%s_mass_nom" % self.jetBranchName, jets_mass_nom)
@@ -573,10 +588,15 @@ class jetmetUncertaintiesProducer(Module):
               self.out.fillBranch("%s_pt_jes%sUp" % (self.jetBranchName, jesUncertainty), jets_pt_jesUp[jesUncertainty])
               self.out.fillBranch("%s_pt_jes%sDown" % (self.jetBranchName, jesUncertainty), jets_pt_jesDown[jesUncertainty])
               
-              self.out.fillBranch("%s_pt_jes%sUp" % (self.metBranchName, jesUncertainty), math.sqrt(met_px_jesUp[jesUncertainty]**2 + met_py_jesUp[jesUncertainty]**2))
-              self.out.fillBranch("%s_phi_jes%sUp" % (self.metBranchName, jesUncertainty), math.atan2(met_py_jesUp[jesUncertainty], met_px_jesUp[jesUncertainty]))
-              self.out.fillBranch("%s_pt_jes%sDown" % (self.metBranchName, jesUncertainty), math.sqrt(met_px_jesDown[jesUncertainty]**2 + met_py_jesDown[jesUncertainty]**2))
-              self.out.fillBranch("%s_phi_jes%sDown" % (self.metBranchName, jesUncertainty), math.atan2(met_py_jesDown[jesUncertainty], met_px_jesDown[jesUncertainty]))
+              self.out.fillBranch("%s_T1_pt_jes%sUp" % (self.metBranchName, jesUncertainty), math.sqrt(met_T1_px_jesUp[jesUncertainty]**2 + met_T1_py_jesUp[jesUncertainty]**2))
+              self.out.fillBranch("%s_T1_phi_jes%sUp" % (self.metBranchName, jesUncertainty), math.atan2(met_T1_py_jesUp[jesUncertainty], met_T1_px_jesUp[jesUncertainty]))
+              self.out.fillBranch("%s_T1_pt_jes%sDown" % (self.metBranchName, jesUncertainty), math.sqrt(met_T1_px_jesDown[jesUncertainty]**2 + met_T1_py_jesDown[jesUncertainty]**2))
+              self.out.fillBranch("%s_T1_phi_jes%sDown" % (self.metBranchName, jesUncertainty), math.atan2(met_T1_py_jesDown[jesUncertainty], met_T1_px_jesDown[jesUncertainty]))
+
+              self.out.fillBranch("%s_T1Smear_pt_jes%sUp" % (self.metBranchName, jesUncertainty), math.sqrt(met_T1Smear_px_jesUp[jesUncertainty]**2 + met_T1Smear_py_jesUp[jesUncertainty]**2))
+              self.out.fillBranch("%s_T1Smear_phi_jes%sUp" % (self.metBranchName, jesUncertainty), math.atan2(met_T1Smear_py_jesUp[jesUncertainty], met_T1Smear_px_jesUp[jesUncertainty]))
+              self.out.fillBranch("%s_T1Smear_pt_jes%sDown" % (self.metBranchName, jesUncertainty), math.sqrt(met_T1Smear_px_jesDown[jesUncertainty]**2 + met_T1Smear_py_jesDown[jesUncertainty]**2))
+              self.out.fillBranch("%s_T1Smear_phi_jes%sDown" % (self.metBranchName, jesUncertainty), math.atan2(met_T1Smear_py_jesDown[jesUncertainty], met_T1Smear_px_jesDown[jesUncertainty]))
               
               self.out.fillBranch("%s_mass_jes%sUp" % (self.jetBranchName, jesUncertainty), jets_mass_jesUp[jesUncertainty])
               self.out.fillBranch("%s_mass_jes%sDown" % (self.jetBranchName, jesUncertainty), jets_mass_jesDown[jesUncertainty])

--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -366,6 +366,7 @@ class jetmetUncertaintiesProducer(Module):
             # (cf. https://twiki.cern.ch/twiki/bin/view/CMS/JetResolution and https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyResolution )
             if not self.isData:
               ( jet_pt_jerNomVal, jet_pt_jerUpVal, jet_pt_jerDownVal ) = self.jetSmearer.getSmearValsPt(jet, genJet, rho)
+              ( jet_pt_jerNomVal_T1Smear, jet_pt_jerUpVal_T1Smear, jet_pt_jerDownVal_T1Smear) = self.jetSmearer.getSmearValsPt(jet, genJet, rho, t1smear=True)
             else:
               # if you want to do something with JER in data, please add it here.
               ( jet_pt_jerNomVal, jet_pt_jerUpVal, jet_pt_jerDownVal ) = (1,1,1)
@@ -499,10 +500,10 @@ class jetmetUncertaintiesProducer(Module):
                           met_T1_px_jesDown[jesUncertainty] = met_T1_px_jesDown[jesUncertainty] - (jet_pt_jesDownT1[jesUncertainty] - jet_pt_L1)*jet_cosPhi
                           met_T1_py_jesDown[jesUncertainty] = met_T1_py_jesDown[jesUncertainty] - (jet_pt_jesDownT1[jesUncertainty] - jet_pt_L1)*jet_sinPhi
                           # Calculate JES uncertainties on smeared MET
-                          met_T1Smear_px_jesUp[jesUncertainty]   = met_T1Smear_px_jesUp[jesUncertainty]   - (jet_pt_jesUpT1[jesUncertainty]   - jet_pt_L1)*jet_pt_jerNomVal*jet_cosPhi
-                          met_T1Smear_py_jesUp[jesUncertainty]   = met_T1Smear_py_jesUp[jesUncertainty]   - (jet_pt_jesUpT1[jesUncertainty]   - jet_pt_L1)*jet_pt_jerNomVal*jet_sinPhi
-                          met_T1Smear_px_jesDown[jesUncertainty] = met_T1Smear_px_jesDown[jesUncertainty] - (jet_pt_jesDownT1[jesUncertainty] - jet_pt_L1)*jet_pt_jerNomVal*jet_cosPhi
-                          met_T1Smear_py_jesDown[jesUncertainty] = met_T1Smear_py_jesDown[jesUncertainty] - (jet_pt_jesDownT1[jesUncertainty] - jet_pt_L1)*jet_pt_jerNomVal*jet_sinPhi
+                          met_T1Smear_px_jesUp[jesUncertainty]   = met_T1Smear_px_jesUp[jesUncertainty]   - (jet_pt_jesUpT1[jesUncertainty]   - jet_pt_L1)*jet_pt_jerNomVal_T1Smear*jet_cosPhi
+                          met_T1Smear_py_jesUp[jesUncertainty]   = met_T1Smear_py_jesUp[jesUncertainty]   - (jet_pt_jesUpT1[jesUncertainty]   - jet_pt_L1)*jet_pt_jerNomVal_T1Smear*jet_sinPhi
+                          met_T1Smear_px_jesDown[jesUncertainty] = met_T1Smear_px_jesDown[jesUncertainty] - (jet_pt_jesDownT1[jesUncertainty] - jet_pt_L1)*jet_pt_jerNomVal_T1Smear*jet_cosPhi
+                          met_T1Smear_py_jesDown[jesUncertainty] = met_T1Smear_py_jesDown[jesUncertainty] - (jet_pt_jesDownT1[jesUncertainty] - jet_pt_L1)*jet_pt_jerNomVal_T1Smear*jet_sinPhi
 
 
         # propagate "unclustered energy" uncertainty to MET

--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -513,9 +513,8 @@ class jetmetUncertaintiesProducer(Module):
                       # Variations of T1 MET
                       if 'T1' in self.saveMETUncs: 
                         for jerID in self.splitJERIDs:
+                            # For uncertainties on T1 MET, the up/down variations are just the centrally smeared MET values
                             jerUpVal, jerDownVal = jet_pt_jerNomVal, jet_pt_jerNomVal
-                            if jerID == self.getJERsplitID(jet_pt_nom, jet.eta):
-                                jerUpVal, jerDownVal = jet_pt_jerUpVal, jet_pt_jerDownVal
                             met_T1_px_jerUp[jerID]   = met_T1_px_jerUp[jerID]   - (jet_pt_L1L2L3*jerUpVal    - jet_pt_L1)*jet_cosPhi
                             met_T1_py_jerUp[jerID]   = met_T1_py_jerUp[jerID]   - (jet_pt_L1L2L3*jerUpVal    - jet_pt_L1)*jet_sinPhi
                             met_T1_px_jerDown[jerID] = met_T1_px_jerDown[jerID] - (jet_pt_L1L2L3*jerDownVal  - jet_pt_L1)*jet_cosPhi

--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -365,8 +365,12 @@ class jetmetUncertaintiesProducer(Module):
             # evaluate JER scale factors and uncertainties
             # (cf. https://twiki.cern.ch/twiki/bin/view/CMS/JetResolution and https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyResolution )
             if not self.isData:
-              ( jet_pt_jerNomVal, jet_pt_jerUpVal, jet_pt_jerDownVal ) = self.jetSmearer.getSmearValsPt(jet, genJet, rho)
+              # Get the smearing factors for T1 MET correction
+              ( jet_pt_jerNomVal_T1, jet_pt_jerUpVal_T1, jet_pt_jerDownVal_T1 ) = self.jetSmearer.getSmearValsPt(jet, genJet, rho)
+              
+              # Get the smearing factors for T1Smear MET correction
               ( jet_pt_jerNomVal_T1Smear, jet_pt_jerUpVal_T1Smear, jet_pt_jerDownVal_T1Smear) = self.jetSmearer.getSmearValsPt(jet, genJet, rho, t1smear=True)
+              ( jet_pt_jerNomVal, jet_pt_jerUpVal, jet_pt_jerDownVal ) = ( jet_pt_jerNomVal_T1Smear, jet_pt_jerUpVal_T1Smear, jet_pt_jerDownVal_T1Smear )
             else:
               # if you want to do something with JER in data, please add it here.
               ( jet_pt_jerNomVal, jet_pt_jerUpVal, jet_pt_jerDownVal ) = (1,1,1)

--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -369,14 +369,11 @@ class jetmetUncertaintiesProducer(Module):
             # evaluate JER scale factors and uncertainties
             # (cf. https://twiki.cern.ch/twiki/bin/view/CMS/JetResolution and https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyResolution )
             if not self.isData:
-              # Smearing factors for jets
-              ( jet_pt_jerNomVal, jet_pt_jerUpVal, jet_pt_jerDownVal ) = self.jetSmearer.getSmearValsPt(jet, genJet, rho, t1Smear=True)
-              if not self.useT1SmearMETforUncs:
-                  # Get the smearing factors for T1 MET correction
-                  ( jet_pt_jerNomVal_T1, jet_pt_jerUpVal_T1, jet_pt_jerDownVal_T1 ) = self.jetSmearer.getSmearValsPt(jet, genJet, rho)
-              else:
-                  # Get the smearing factors for T1Smear MET correction
-                  ( jet_pt_jerNomVal_T1Smear, jet_pt_jerUpVal_T1Smear, jet_pt_jerDownVal_T1Smear ) = self.jetSmearer.getSmearValsPt(jet, genJet, rho, t1Smear=True)
+              # Get the smearing factors for T1 MET correction
+              ( jet_pt_jerNomVal_T1, jet_pt_jerUpVal_T1, jet_pt_jerDownVal_T1 ) = self.jetSmearer.getSmearValsPt(jet, genJet, rho)
+              # Get the smearing factors for T1Smear MET correction
+              ( jet_pt_jerNomVal_T1Smear, jet_pt_jerUpVal_T1Smear, jet_pt_jerDownVal_T1Smear ) = self.jetSmearer.getSmearValsPt(jet, genJet, rho, t1Smear=True)
+              ( jet_pt_jerNomVal, jet_pt_jerUpVal, jet_pt_jerDownVal ) = ( jet_pt_jerNomVal_T1Smear, jet_pt_jerUpVal_T1Smear, jet_pt_jerDownVal_T1Smear )
             else:
               # if you want to do something with JER in data, please add it here.
               ( jet_pt_jerNomVal, jet_pt_jerUpVal, jet_pt_jerDownVal ) = (1,1,1)
@@ -601,17 +598,17 @@ class jetmetUncertaintiesProducer(Module):
               self.out.fillBranch("%s_pt_jes%sUp" % (self.jetBranchName, jesUncertainty), jets_pt_jesUp[jesUncertainty])
               self.out.fillBranch("%s_pt_jes%sDown" % (self.jetBranchName, jesUncertainty), jets_pt_jesDown[jesUncertainty])
               
-              if self.useT1SmearMETforUncs:
-                  self.out.fillBranch("%s_T1Smear_pt_jes%sUp" % (self.metBranchName, jesUncertainty), math.sqrt(met_T1_px_jesUp[jesUncertainty]**2 + met_T1_py_jesUp[jesUncertainty]**2))
-                  self.out.fillBranch("%s_T1Smear_phi_jes%sUp" % (self.metBranchName, jesUncertainty), math.atan2(met_T1_py_jesUp[jesUncertainty], met_T1_px_jesUp[jesUncertainty]))
-                  self.out.fillBranch("%s_T1Smear_pt_jes%sDown" % (self.metBranchName, jesUncertainty), math.sqrt(met_T1_px_jesDown[jesUncertainty]**2 + met_T1_py_jesDown[jesUncertainty]**2))
-                  self.out.fillBranch("%s_T1Smear_phi_jes%sDown" % (self.metBranchName, jesUncertainty), math.atan2(met_T1_py_jesDown[jesUncertainty], met_T1_px_jesDown[jesUncertainty]))
+              if not self.useT1SmearMETforUncs:
+                  self.out.fillBranch("%s_T1_pt_jes%sUp" % (self.metBranchName, jesUncertainty), math.sqrt(met_T1_px_jesUp[jesUncertainty]**2 + met_T1_py_jesUp[jesUncertainty]**2))
+                  self.out.fillBranch("%s_T1_phi_jes%sUp" % (self.metBranchName, jesUncertainty), math.atan2(met_T1_py_jesUp[jesUncertainty], met_T1_px_jesUp[jesUncertainty]))
+                  self.out.fillBranch("%s_T1_pt_jes%sDown" % (self.metBranchName, jesUncertainty), math.sqrt(met_T1_px_jesDown[jesUncertainty]**2 + met_T1_py_jesDown[jesUncertainty]**2))
+                  self.out.fillBranch("%s_T1_phi_jes%sDown" % (self.metBranchName, jesUncertainty), math.atan2(met_T1_py_jesDown[jesUncertainty], met_T1_px_jesDown[jesUncertainty]))
 
               else:
-                  self.out.fillBranch("%s_T1_pt_jes%sUp" % (self.metBranchName, jesUncertainty), math.sqrt(met_T1Smear_px_jesUp[jesUncertainty]**2 + met_T1Smear_py_jesUp[jesUncertainty]**2))
-                  self.out.fillBranch("%s_T1_phi_jes%sUp" % (self.metBranchName, jesUncertainty), math.atan2(met_T1Smear_py_jesUp[jesUncertainty], met_T1Smear_px_jesUp[jesUncertainty]))
-                  self.out.fillBranch("%s_T1_pt_jes%sDown" % (self.metBranchName, jesUncertainty), math.sqrt(met_T1Smear_px_jesDown[jesUncertainty]**2 + met_T1Smear_py_jesDown[jesUncertainty]**2))
-                  self.out.fillBranch("%s_T1_phi_jes%sDown" % (self.metBranchName, jesUncertainty), math.atan2(met_T1Smear_py_jesDown[jesUncertainty], met_T1Smear_px_jesDown[jesUncertainty]))
+                  self.out.fillBranch("%s_T1Smear_pt_jes%sUp" % (self.metBranchName, jesUncertainty), math.sqrt(met_T1Smear_px_jesUp[jesUncertainty]**2 + met_T1Smear_py_jesUp[jesUncertainty]**2))
+                  self.out.fillBranch("%s_T1Smear_phi_jes%sUp" % (self.metBranchName, jesUncertainty), math.atan2(met_T1Smear_py_jesUp[jesUncertainty], met_T1Smear_px_jesUp[jesUncertainty]))
+                  self.out.fillBranch("%s_T1Smear_pt_jes%sDown" % (self.metBranchName, jesUncertainty), math.sqrt(met_T1Smear_px_jesDown[jesUncertainty]**2 + met_T1Smear_py_jesDown[jesUncertainty]**2))
+                  self.out.fillBranch("%s_T1Smear_phi_jes%sDown" % (self.metBranchName, jesUncertainty), math.atan2(met_T1Smear_py_jesDown[jesUncertainty], met_T1Smear_px_jesDown[jesUncertainty]))
               
               self.out.fillBranch("%s_mass_jes%sUp" % (self.jetBranchName, jesUncertainty), jets_mass_jesUp[jesUncertainty])
               self.out.fillBranch("%s_mass_jes%sDown" % (self.jetBranchName, jesUncertainty), jets_mass_jesDown[jesUncertainty])


### PR DESCRIPTION
This PR contains new code that has:

- Separate calculations of JME uncertainties for T1 and T1Smear MET, which are stored in different branches
- An option flag in jetmetHelper to specify which MET uncertainties (T1 or T1Smear) are to be saved

