### PR TITLE
Minor updates to the code: p4() with correced pT; clock() to time() change

### DIFF
--- a/python/postprocessing/framework/datamodel.py
+++ b/python/postprocessing/framework/datamodel.py
@@ -64,9 +64,12 @@ class Object:
         return val
     def __getitem__(self,attr):
         return self.__getattr__(attr)
-    def p4(self):
+    def p4(self, corr_pt=None):
         ret = ROOT.TLorentzVector()
-        ret.SetPtEtaPhiM(self.pt,self.eta,self.phi,self.mass)
+        if corr_pt == None:
+            ret.SetPtEtaPhiM(self.pt,self.eta,self.phi,self.mass)
+        else:
+            ret.SetPtEtaPhiM(corr_pt,self.eta,self.phi,self.mass)
         return ret
     def DeltaR(self,other):
         if isinstance(other,ROOT.TLorentzVector):

--- a/python/postprocessing/framework/postprocessor.py
+++ b/python/postprocessing/framework/postprocessor.py
@@ -35,7 +35,14 @@ class PostProcessor :
 		print "Because you requested a FJR we assume you want the final hadd. No name specified for the output file, will use tree.root"
 		self.haddFileName="tree.root"
  	self.branchsel = BranchSelection(branchsel) if branchsel else None 
-        self.outputbranchsel = BranchSelection(outputbranchsel) if outputbranchsel else None
+        if outputbranchsel != None:
+            self.outputbranchsel = BranchSelection(outputbranchsel)
+        elif outputbranchsel == None and branchsel != None:
+            # Use the same branches in the output as in input
+            self.outputbranchsel = BranchSelection(branchsel)
+        else: 
+            self.outputbranchsel = None
+
         self.histFileName=histFileName
         self.histDirName=histDirName
         self.maxEntries = maxEntries if maxEntries else 9223372036854775807L # 2^63 - 1, largest int64

--- a/python/postprocessing/framework/postprocessor.py
+++ b/python/postprocessing/framework/postprocessor.py
@@ -202,7 +202,7 @@ class PostProcessor :
 		
 	for m in self.modules: m.endJob()
 	
-	print  totEntriesRead/(time.time()-t0), "Hz"
+	print "Total time %.1f sec. to process %i events. Rate = %.1f Hz." %((time.time()-t0), totEntriesRead, totEntriesRead/(time.time()-t0))
 
 
 	if self.haddFileName :

--- a/python/postprocessing/framework/postprocessor.py
+++ b/python/postprocessing/framework/postprocessor.py
@@ -108,7 +108,7 @@ class PostProcessor :
 
 	fullClone = (len(self.modules) == 0)
 	outFileNames=[]
-        t0 = time.clock()
+        t0 = time.time()
 	totEntriesRead=0
 	for fname in self.inputFiles:
 	    ffnames = []
@@ -202,7 +202,7 @@ class PostProcessor :
 		
 	for m in self.modules: m.endJob()
 	
-	print  totEntriesRead/(time.clock()-t0), "Hz"
+	print  totEntriesRead/(time.time()-t0), "Hz"
 
 
 	if self.haddFileName :

--- a/src/WeightCalculatorFromHistogram.cc
+++ b/src/WeightCalculatorFromHistogram.cc
@@ -50,7 +50,7 @@ std::vector<float> WeightCalculatorFromHistogram::loadVals(TH1 *hist, bool norm)
   std::vector<float> vals;
   for(int i=0; i<nbins; ++i) {
     double bc=hist->GetBinContent(i);
-    double val = (i>0 && bc==0 && hist->GetBinContent(i-1)>0 && hist->GetBinContent(i+1)>0) ? 0.5*(hist->GetBinContent(i-1)+hist->GetBinContent(i+1)) : bc;
+    //double val = (i>0 && bc==0 && hist->GetBinContent(i-1)>0 && hist->GetBinContent(i+1)>0) ? 0.5*(hist->GetBinContent(i-1)+hist->GetBinContent(i+1)) : bc;
     vals.push_back(std::max(bc,0.));
   }
   if(verbose_) std::cout << "Normalization of " << hist->GetName() << ": " << hist->Integral() << std::endl;


### PR DESCRIPTION
Here is just few small proposals for updates:
* make it possible in p4() method to provide a new pT, that is, use p4(corr_pt). This is useful to replace the muon momentum with corrected_pt variables from rochester correction functions.
* changed time.clock to time.time, to be consistent with #226 
* imporoved the way output branches are masked (keep and drop file). If input mask is provided, but the output mask is not, the input mask is used for the output as well. The branches masked at the input are empty in the output anyway. If the output mask is provided - it is used instead (it should be more restrictive than input, but this is not checked).
