### PR TITLE
Fixup: Create some correction branches only for MC

### DIFF
--- a/python/postprocessing/modules/jme/fatJetUncertainties.py
+++ b/python/postprocessing/modules/jme/fatJetUncertainties.py
@@ -249,15 +249,6 @@ class fatJetUncertaintiesProducer(Module):
         self.out.branch("%s_corr_JEC" % self.jetBranchName,
                         "F",
                         lenVar=self.lenVar)
-        self.out.branch("%s_corr_JER" % self.jetBranchName,
-                        "F",
-                        lenVar=self.lenVar)
-        self.out.branch("%s_corr_JMS" % self.jetBranchName,
-                        "F",
-                        lenVar=self.lenVar)
-        self.out.branch("%s_corr_JMR" % self.jetBranchName,
-                        "F",
-                        lenVar=self.lenVar)
 
         if self.doGroomed:
             self.out.branch("%s_msoftdrop_raw" % self.jetBranchName,
@@ -280,6 +271,16 @@ class fatJetUncertaintiesProducer(Module):
             self.out.branch("%s_msoftdrop_tau21DDT_nom" % self.jetBranchName,
                             "F",
                             lenVar=self.lenVar)
+            self.out.branch("%s_corr_JMR" % self.jetBranchName,
+                            "F",
+                            lenVar=self.lenVar)
+            self.out.branch("%s_corr_JER" % self.jetBranchName,
+                            "F",
+                            lenVar=self.lenVar)
+            self.out.branch("%s_corr_JMS" % self.jetBranchName,
+                            "F",
+                            lenVar=self.lenVar)
+
             for shift in ["Up", "Down"]:
                 for jerID in self.splitJERIDs:
                     self.out.branch("%s_pt_jer%s%s" %


### PR DESCRIPTION
Hello, this PR provides a fix for an issue in fat jet JME module. With the changes in PR #251, FatJet_corr_JMR, FatJet_corr_JER and FatJet_corr_JMS branches are created for both data and MC, in [1] (unlike earlier versions, where they were only created for MC).  

In our specific case, this difference caused a problem while running on data. Specifically the problem came from a later FatJet Collector module, you can find the full traceback in [2]. I believe this issue is caused by these branches being created for data as well, in the version in this PR these three branches are created only for MC (like older versions) and we didn't encounter a problem running on data.

Please let me know if you want any changes to this, thanks so much!

[1] https://github.com/cms-nanoAOD/nanoAOD-tools/blob/master/python/postprocessing/modules/jme/fatJetUncertainties.py#L252-L260

[2]
Traceback (most recent call last):
  File "crab_script_monojet.py", line 211, in <module>
    main()
  File "crab_script_monojet.py", line 204, in main
    p.run()
  File "/uscms_data/d3/aakpinar/MYWORKINGAREA/CMSSW_10_2_15/python/PhysicsTools/NanoAODTools/postprocessing/framework/postprocessor.py", line 234, in run
    eventRange=eventRange, maxEvents=self.maxEntries
  File "/uscms_data/d3/aakpinar/MYWORKINGAREA/CMSSW_10_2_15/python/PhysicsTools/NanoAODTools/postprocessing/framework/eventloop.py", line 78, in eventLoop
    ret = m.analyze(e)
  File "/uscms_data/d3/aakpinar/MYWORKINGAREA/CMSSW_10_2_15/python/PhysicsTools/NanoAODTools/postprocessing/modules/common/collectionMerger.py", line 120, in analyze
    out.append(getattr(obj, br) if self.is_there[bridx][j] else 0)
  File "/uscms_data/d3/aakpinar/MYWORKINGAREA/CMSSW_10_2_15/python/PhysicsTools/NanoAODTools/postprocessing/framework/datamodel.py", line 69, in __getattr__
    val = getattr(self._event, self._prefix + name)
  File "/uscms_data/d3/aakpinar/MYWORKINGAREA/CMSSW_10_2_15/python/PhysicsTools/NanoAODTools/postprocessing/framework/datamodel.py", line 18, in __getattr__
    return self._tree.readBranch(name)
  File "/uscms_data/d3/aakpinar/MYWORKINGAREA/CMSSW_10_2_15/python/PhysicsTools/NanoAODTools/postprocessing/framework/treeReaderArrayTools.py", line 76, in readBranch
    raise RuntimeError("Unknown branch %s" % branchName)
RuntimeError: Unknown branch FatJet_corr_JMR