### PR TITLE
Fix JES uncertainties on T1(smear) MET with split JER (indentation)

### DIFF
--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -729,28 +729,28 @@ class jetmetUncertaintiesProducer(Module):
                                     jerID] - (jet_pt_L1L2L3 * jerDownVal -
                                               jet_pt_L1) * jet_sinPhi
 
-                                # Calculate JES uncertainties on unsmeared MET
-                                for jesUncertainty in self.jesUncertainties:
-                                    met_T1_px_jesUp[
-                                        jesUncertainty] = met_T1_px_jesUp[
-                                            jesUncertainty] - (
-                                                jet_pt_jesUpT1[jesUncertainty]
-                                                - jet_pt_L1) * jet_cosPhi
-                                    met_T1_py_jesUp[
-                                        jesUncertainty] = met_T1_py_jesUp[
-                                            jesUncertainty] - (
-                                                jet_pt_jesUpT1[jesUncertainty]
-                                                - jet_pt_L1) * jet_sinPhi
-                                    met_T1_px_jesDown[
-                                        jesUncertainty] = met_T1_px_jesDown[
-                                            jesUncertainty] - (
-                                                jet_pt_jesDownT1[jesUncertainty]
-                                                - jet_pt_L1) * jet_cosPhi
-                                    met_T1_py_jesDown[
-                                        jesUncertainty] = met_T1_py_jesDown[
-                                            jesUncertainty] - (
-                                                jet_pt_jesDownT1[jesUncertainty]
-                                                - jet_pt_L1) * jet_sinPhi
+                            # Calculate JES uncertainties on unsmeared MET
+                            for jesUncertainty in self.jesUncertainties:
+                                met_T1_px_jesUp[
+                                    jesUncertainty] = met_T1_px_jesUp[
+                                        jesUncertainty] - (
+                                            jet_pt_jesUpT1[jesUncertainty]
+                                            - jet_pt_L1) * jet_cosPhi
+                                met_T1_py_jesUp[
+                                    jesUncertainty] = met_T1_py_jesUp[
+                                        jesUncertainty] - (
+                                            jet_pt_jesUpT1[jesUncertainty]
+                                            - jet_pt_L1) * jet_sinPhi
+                                met_T1_px_jesDown[
+                                    jesUncertainty] = met_T1_px_jesDown[
+                                        jesUncertainty] - (
+                                            jet_pt_jesDownT1[jesUncertainty]
+                                            - jet_pt_L1) * jet_cosPhi
+                                met_T1_py_jesDown[
+                                    jesUncertainty] = met_T1_py_jesDown[
+                                        jesUncertainty] - (
+                                            jet_pt_jesDownT1[jesUncertainty]
+                                            - jet_pt_L1) * jet_sinPhi
                         # Variations of T1Smear MET
                         if 'T1Smear' in self.saveMETUncs:
                             for jerID in self.splitJERIDs:
@@ -775,26 +775,26 @@ class jetmetUncertaintiesProducer(Module):
                                         jet_pt_L1L2L3 * jerDownVal -
                                         jet_pt_L1) * jet_sinPhi
 
-                                # Calculate JES uncertainties on smeared MET
-                                for jesUncertainty in self.jesUncertainties:
-                                    jesUp_correction_forT1SmearMET = (
-                                        jet_pt_L1L2L3 * jet_pt_jerNomVal -
-                                        jet_pt_L1) + (
-                                            jet_pt_jesUpT1[jesUncertainty] -
-                                            jet_pt_L1L2L3)
-                                    jesDown_correction_forT1SmearMET = (
-                                        jet_pt_L1L2L3 * jet_pt_jerNomVal -
-                                        jet_pt_L1) + (
-                                            jet_pt_jesDownT1[jesUncertainty] -
-                                            jet_pt_L1L2L3)
-                                    met_T1Smear_px_jesUp[jesUncertainty] = met_T1Smear_px_jesUp[jesUncertainty] - \
-                                        jesUp_correction_forT1SmearMET * jet_cosPhi
-                                    met_T1Smear_py_jesUp[jesUncertainty] = met_T1Smear_py_jesUp[jesUncertainty] - \
-                                        jesUp_correction_forT1SmearMET * jet_sinPhi
-                                    met_T1Smear_px_jesDown[jesUncertainty] = met_T1Smear_px_jesDown[jesUncertainty] - \
-                                        jesDown_correction_forT1SmearMET * jet_cosPhi
-                                    met_T1Smear_py_jesDown[jesUncertainty] = met_T1Smear_py_jesDown[jesUncertainty] - \
-                                        jesDown_correction_forT1SmearMET * jet_sinPhi
+                            # Calculate JES uncertainties on smeared MET
+                            for jesUncertainty in self.jesUncertainties:
+                                jesUp_correction_forT1SmearMET = (
+                                    jet_pt_L1L2L3 * jet_pt_jerNomVal -
+                                    jet_pt_L1) + (
+                                        jet_pt_jesUpT1[jesUncertainty] -
+                                        jet_pt_L1L2L3)
+                                jesDown_correction_forT1SmearMET = (
+                                    jet_pt_L1L2L3 * jet_pt_jerNomVal -
+                                    jet_pt_L1) + (
+                                        jet_pt_jesDownT1[jesUncertainty] -
+                                        jet_pt_L1L2L3)
+                                met_T1Smear_px_jesUp[jesUncertainty] = met_T1Smear_px_jesUp[jesUncertainty] - \
+                                    jesUp_correction_forT1SmearMET * jet_cosPhi
+                                met_T1Smear_py_jesUp[jesUncertainty] = met_T1Smear_py_jesUp[jesUncertainty] - \
+                                    jesUp_correction_forT1SmearMET * jet_sinPhi
+                                met_T1Smear_px_jesDown[jesUncertainty] = met_T1Smear_px_jesDown[jesUncertainty] - \
+                                    jesDown_correction_forT1SmearMET * jet_cosPhi
+                                met_T1Smear_py_jesDown[jesUncertainty] = met_T1Smear_py_jesDown[jesUncertainty] - \
+                                    jesDown_correction_forT1SmearMET * jet_sinPhi
 
         # propagate "unclustered energy" uncertainty to MET
         if self.metBranchName == 'METFixEE2017':


### PR DESCRIPTION
Since the loop over JES uncertainty sources was put inside the one over JER bins in https://github.com/cms-nanoAOD/nanoAOD-tools/pull/244, the JES variations are applied six times instead of once if JER uncertainty splitting is enabled.
I just removed the indentation, but I guess this also allows for some of the line splitting to be reverted - let me know if there's some script/guideline for this.