### PR TITLE
Fix missing 'not'

### DIFF
--- a/python/postprocessing/framework/postprocessor.py
+++ b/python/postprocessing/framework/postprocessor.py
@@ -130,7 +130,7 @@ class PostProcessor:
         if (self.histFileName is not None and self.histDirName is None) or (self.histFileName is None and self.histDirName is not None):
             raise RuntimeError(
                 "Must specify both histogram file and histogram directory!")
-        elif self.histFileName is not None and self.histDirName is None:
+        elif self.histFileName is not None and self.histDirName is not None:
             self.histFile = ROOT.TFile.Open(self.histFileName, "RECREATE")
         else:
             self.histFile = None


### PR DESCRIPTION
This PR fixes a missing `not` in `python/postprocessing/framework/postprocessor.py`. I made a [comment](https://github.com/cms-nanoAOD/nanoAOD-tools/pull/255/files#r521145897) here in PR #255.