### PR TITLE
Unclustered energy variations for T1Smear

### DIFF
--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -314,9 +314,13 @@ class jetmetUncertaintiesProducer(Module):
                             (self.metBranchName, jesUncertainty, shift), "F")
 
                 self.out.branch(
-                    "%s_pt_unclustEn%s" % (self.metBranchName, shift), "F")
+                    "%s_T1_pt_unclustEn%s" % (self.metBranchName, shift), "F")
                 self.out.branch(
-                    "%s_phi_unclustEn%s" % (self.metBranchName, shift), "F")
+                    "%s_T1_phi_unclustEn%s" % (self.metBranchName, shift), "F")
+                self.out.branch(
+                    "%s_T1Smear_pt_unclustEn%s" % (self.metBranchName, shift), "F")
+                self.out.branch(
+                    "%s_T1Smear_phi_unclustEn%s" % (self.metBranchName, shift), "F")
 
         self.isV5NanoAOD = hasattr(inputTree, "Jet_muonSubtrFactor")
         print("nanoAODv5 or higher: " + str(self.isV5NanoAOD))
@@ -857,16 +861,22 @@ class jetmetUncertaintiesProducer(Module):
                         jesUncertainty] += delta_y_rawJet - met_unclEE_y
 
         if not self.isData:
-            (met_px_unclEnUp, met_py_unclEnUp) = (met_T1_px, met_T1_py)
-            (met_px_unclEnDown, met_py_unclEnDown) = (met_T1_px, met_T1_py)
+            (met_T1_px_unclEnUp, met_T1_py_unclEnUp) = (met_T1_px, met_T1_py)
+            (met_T1_px_unclEnDown, met_T1_py_unclEnDown) = (met_T1_px, met_T1_py)
+            (met_T1Smear_px_unclEnUp, met_T1Smear_py_unclEnUp) = (met_T1Smear_px, met_T1Smear_py)
+            (met_T1Smear_px_unclEnDown, met_T1Smear_py_unclEnDown) = (met_T1Smear_px, met_T1Smear_py)
             met_deltaPx_unclEn = getattr(
                 event, self.metBranchName + "_MetUnclustEnUpDeltaX")
             met_deltaPy_unclEn = getattr(
                 event, self.metBranchName + "_MetUnclustEnUpDeltaY")
-            met_px_unclEnUp = met_px_unclEnUp + met_deltaPx_unclEn
-            met_py_unclEnUp = met_py_unclEnUp + met_deltaPy_unclEn
-            met_px_unclEnDown = met_px_unclEnDown - met_deltaPx_unclEn
-            met_py_unclEnDown = met_py_unclEnDown - met_deltaPy_unclEn
+            met_T1_px_unclEnUp = met_T1_px_unclEnUp + met_deltaPx_unclEn
+            met_T1_py_unclEnUp = met_T1_py_unclEnUp + met_deltaPy_unclEn
+            met_T1_px_unclEnDown = met_T1_px_unclEnDown - met_deltaPx_unclEn
+            met_T1_py_unclEnDown = met_T1_py_unclEnDown - met_deltaPy_unclEn
+            met_T1Smear_px_unclEnUp = met_T1Smear_px_unclEnUp + met_deltaPx_unclEn
+            met_T1Smear_py_unclEnUp = met_T1Smear_py_unclEnUp + met_deltaPy_unclEn
+            met_T1Smear_px_unclEnDown = met_T1Smear_px_unclEnDown - met_deltaPx_unclEn
+            met_T1Smear_py_unclEnDown = met_T1Smear_py_unclEnDown - met_deltaPy_unclEn
 
         self.out.fillBranch("%s_pt_raw" % self.jetBranchName, jets_pt_raw)
         self.out.fillBranch("%s_pt_nom" % self.jetBranchName, jets_pt_nom)
@@ -1005,16 +1015,27 @@ class jetmetUncertaintiesProducer(Module):
                     jets_mass_jesDown[jesUncertainty])
 
             self.out.fillBranch(
-                "%s_pt_unclustEnUp" % self.metBranchName,
-                math.sqrt(met_px_unclEnUp**2 + met_py_unclEnUp**2))
-            self.out.fillBranch("%s_phi_unclustEnUp" % self.metBranchName,
-                                math.atan2(met_py_unclEnUp, met_px_unclEnUp))
+                "%s_T1_pt_unclustEnUp" % self.metBranchName,
+                math.sqrt(met_T1_px_unclEnUp**2 + met_T1_py_unclEnUp**2))
+            self.out.fillBranch("%s_T1_phi_unclustEnUp" % self.metBranchName,
+                                math.atan2(met_T1_py_unclEnUp, met_T1_px_unclEnUp))
             self.out.fillBranch(
-                "%s_pt_unclustEnDown" % self.metBranchName,
-                math.sqrt(met_px_unclEnDown**2 + met_py_unclEnDown**2))
+                "%s_T1_pt_unclustEnDown" % self.metBranchName,
+                math.sqrt(met_T1_px_unclEnDown**2 + met_T1_py_unclEnDown**2))
             self.out.fillBranch(
-                "%s_phi_unclustEnDown" % self.metBranchName,
-                math.atan2(met_py_unclEnDown, met_px_unclEnDown))
+                "%s_T1_phi_unclustEnDown" % self.metBranchName,
+                math.atan2(met_T1_py_unclEnDown, met_T1_px_unclEnDown))
+            self.out.fillBranch(
+                "%s_T1Smear_pt_unclustEnUp" % self.metBranchName,
+                math.sqrt(met_T1Smear_px_unclEnUp**2 + met_T1Smear_py_unclEnUp**2))
+            self.out.fillBranch("%s_T1Smear_phi_unclustEnUp" % self.metBranchName,
+                                math.atan2(met_T1Smear_py_unclEnUp, met_T1Smear_px_unclEnUp))
+            self.out.fillBranch(
+                "%s_T1Smear_pt_unclustEnDown" % self.metBranchName,
+                math.sqrt(met_T1Smear_px_unclEnDown**2 + met_T1Smear_py_unclEnDown**2))
+            self.out.fillBranch(
+                "%s_T1Smear_phi_unclustEnDown" % self.metBranchName,
+                math.atan2(met_T1Smear_py_unclEnDown, met_T1Smear_px_unclEnDown))
 
         return True
 


### PR DESCRIPTION
Fixes #259 
- rename `MET_(pt,phi)_unclustEn(Up,Down)` -> `MET_T1_(pt,phi)_unclustEn(Up,Down)`
- add `MET_T1Smear_(pt,phi)_unclustEn(Up,Down)` with the same variations calculated with respect to the smeared Type-1 MET.

See also https://github.com/cms-nanoAOD/nanoAOD-tools/pull/256#issuecomment-732112530

Validation: [printout](https://github.com/cms-nanoAOD/nanoAOD-tools/files/5582879/scan_unclustEnSmeared.log) of the relevant variations for master and with the changes for a few events. `MET_T1_*_unclustEn*` is the same as the old branch (rename), the new `MET_T1Smear_(pt,phi)_unclustEn(Up,Down)` variations are in line with expectations.
