### PR TITLE
Two technical updates

### DIFF
--- a/python/postprocessing/framework/branchselection.py
+++ b/python/postprocessing/framework/branchselection.py
@@ -1,4 +1,9 @@
 import re
+try:
+    Pattern = re._pattern_type
+except AttributeError:
+    # Python 3.7
+    Pattern = re.Pattern
 
 
 class BranchSelection():
@@ -39,7 +44,7 @@ class BranchSelection():
         tree.SetBranchStatus("*", 1)
         branchNames = [b.GetName() for b in tree.GetListOfBranches()]
         for bre, stat in self._ops:
-            if type(bre) == re._pattern_type:
+            if type(bre) == Pattern:
                 for n in branchNames:
                     if re.match(bre, n):
                         tree.SetBranchStatus(n, stat)

--- a/python/postprocessing/framework/treeReaderArrayTools.py
+++ b/python/postprocessing/framework/treeReaderArrayTools.py
@@ -30,6 +30,8 @@ def getArrayReader(tree, branchName):
     if branchName not in tree._ttras:
         if not tree.GetBranch(branchName):
             raise RuntimeError("Can't find branch '%s'" % branchName)
+        if not tree.GetBranchStatus(branchName):
+            raise RuntimeError("Branch %s has status=0" % branchName)
         leaf = tree.GetBranch(branchName).GetLeaf(branchName)
         if not bool(leaf.GetLeafCount()):
             raise RuntimeError("Branch %s is not a variable-length value array" % branchName)
@@ -43,6 +45,8 @@ def getValueReader(tree, branchName):
     if branchName not in tree._ttrvs:
         if not tree.GetBranch(branchName):
             raise RuntimeError("Can't find branch '%s'" % branchName)
+        if not tree.GetBranchStatus(branchName):
+            raise RuntimeError("Branch %s has status=0" % branchName)
         leaf = tree.GetBranch(branchName).GetLeaf(branchName)
         if bool(leaf.GetLeafCount()) or leaf.GetLen() != 1:
             raise RuntimeError("Branch %s is not a value" % branchName)
@@ -74,6 +78,8 @@ def readBranch(tree, branchName):
         branch = tree.GetBranch(branchName)
         if not branch:
             raise RuntimeError("Unknown branch %s" % branchName)
+        if not tree.GetBranchStatus(branchName):
+            raise RuntimeError("Branch %s has status=0" % branchName)
         leaf = branch.GetLeaf(branchName)
         typ = leaf.GetTypeName()
         if leaf.GetLen() == 1 and not bool(leaf.GetLeafCount()):


### PR DESCRIPTION
This PR introduces two technical updates:

 - https://github.com/cms-nanoAOD/nanoAOD-tools/commit/0ac785c849d7d4cac327265a423e41414603874c changes the code to raise an error when reading a TTree branch on which `SetBranchStatus(name, 0)` has been called (i.e., when they are dropped in the `keep_and_drop` file). Otherwise the branch reading fails silently, leading to hard-to-detect errors.

- https://github.com/cms-nanoAOD/nanoAOD-tools/commit/bd96eb46171a9ed0824750f65c7fe949e69ac858 fixes a crash in python 3.7+ due to changes in python's `re` package.