### PR TITLE
Make tau tools python3 and standalone compatible

### DIFF
--- a/python/postprocessing/helpers/TauIDSFTool.py
+++ b/python/postprocessing/helpers/TauIDSFTool.py
@@ -4,7 +4,7 @@
 import os
 from math import sqrt
 from PhysicsTools.NanoAODTools.postprocessing.tools import ensureTFile, extractTH1
-datapath  = os.path.join(os.environ['CMSSW_BASE'],"src/PhysicsTools/NanoAODTools/python/postprocessing/data/tau")
+datapath  = os.path.join(os.environ.get('CMSSW_BASE','CMSSW_BASE'),"src/PhysicsTools/NanoAODTools/python/postprocessing/data/tau")
 campaigns = ['2016Legacy','2017ReReco','2018ReReco']
 
 
@@ -150,8 +150,8 @@ class TauESTool:
     def __init__(self, year, id='DeepTau2017v2p1VSjet', path=datapath):
         """Choose the IDs and WPs for SFs."""
         assert year in campaigns, "You must choose a year from %s."%(', '.join(campaigns))
-        file_lowpt  = ensureTFile(os.path.join(datapath,"TauES_dm_%s_%s.root"%(id,year)))
-        file_highpt = ensureTFile(os.path.join(datapath,"TauES_dm_%s_%s_ptgt100.root"%(id,year)))
+        file_lowpt  = ensureTFile(os.path.join(path,"TauES_dm_%s_%s.root"%(id,year)))
+        file_highpt = ensureTFile(os.path.join(path,"TauES_dm_%s_%s_ptgt100.root"%(id,year)))
         self.hist_lowpt  = extractTH1(file_lowpt,'tes')
         self.hist_highpt = extractTH1(file_highpt,'tes')
         self.hist_lowpt.SetDirectory(0)
@@ -211,7 +211,7 @@ class TauFESTool:
     def __init__(self, year, id='DeepTau2017v2p1VSe', path=datapath):
         """Choose the IDs and WPs for SFs."""
         assert year in campaigns, "You must choose a year from %s."%(', '.join(campaigns))
-        file  = ensureTFile(os.path.join(datapath,"TauFES_eta-dm_%s_%s.root"%(id,year)))
+        file  = ensureTFile(os.path.join(path,"TauFES_eta-dm_%s_%s.root"%(id,year)))
         graph = file.Get('fes')
         FESs  = { 'barrel':  { }, 'endcap': { } }
         DMs   = [0,1]

--- a/python/postprocessing/helpers/TauTriggerSFTool.py
+++ b/python/postprocessing/helpers/TauTriggerSFTool.py
@@ -10,13 +10,13 @@ Source: https://github.com/cms-tau-pog/TauTriggerSFs
 import os
 import ROOT
 from math import sqrt
-base = "%s/src/PhysicsTools/NanoAODTools/python/postprocessing/data/tauSF/"%os.environ['CMSSW_BASE']
+datapath  = os.path.join(os.environ.get('CMSSW_BASE','CMSSW_BASE'),"src/PhysicsTools/NanoAODTools/python/postprocessing/data/tau")
 
 
 class TauTriggerSFTool :
     
 
-    def __init__( self, trigger, year=2017, tauWP='medium', wpType='MVAv2' ):
+    def __init__( self, trigger, year=2017, tauWP='medium', wpType='MVAv2', path=datapath ):
 
         self.trigger = trigger
         assert( self.trigger in ['ditau', 'mutau', 'etau'] ), "Choose from: 'ditau', 'mutau', 'etau' triggers."
@@ -28,10 +28,10 @@ class TauTriggerSFTool :
         assert( self.wpType in ['MVAv2', 'dR0p3'] ), "Choose from two provided ID types: 'MVAv2', 'dR0p3'. 'MVAv2' uses dR0p5, and 'dR0p3' is also an MVA-based ID."
         assert( self.wpType == 'MVAv2' ), "Tau POG is currently only providing efficiencies for MVAv2, sorry."
         assert( self.year in [2016, 2017, 2018] ), "Choose which year trigger efficiencies you need."
-        print "Loading Efficiencies for trigger %s usingTau %s ID WP %s for year %i" % (self.trigger, self.wpType, self.tauWP, self.year)
+        print("Loading Efficiencies for trigger %s usingTau %s ID WP %s for year %i" % (self.trigger, self.wpType, self.tauWP, self.year))
 
         # Assume this is in CMSSW with the below path structure
-        self.f = ROOT.TFile( base+'tauTriggerEfficiencies%i.root' % self.year, 'r' )
+        self.f = ROOT.TFile(os.path.join(path,'tauTriggerEfficiencies%i.root'%self.year),'r')
 
 
         ## Load the TF1s containing the analytic best-fit results.
@@ -126,8 +126,8 @@ class TauTriggerSFTool :
         etaPhiVal = etaPhiHist.GetBinContent( etaPhiHist.FindBin( eta, phi ) )
         etaPhiAvg = etaPhiAvgHist.GetBinContent( etaPhiAvgHist.FindBin( eta, phi ) )
         if etaPhiAvg <= 0.0 :
-            print "One of the provided tau (eta, phi) values (%3.3f, %3.3f) is outside the boundary of triggering taus" % (eta, phi)
-            print "Returning efficiency = 0.0"
+            print("One of the provided tau (eta, phi) values (%3.3f, %3.3f) is outside the boundary of triggering taus"%(eta,phi))
+            print("Returning efficiency = 0.0")
             return 0.0
 
         eff *= etaPhiVal / etaPhiAvg
@@ -191,9 +191,9 @@ class TauTriggerSFTool :
         effData = self.getTriggerEfficiencyData( pt, eta, phi, dm )
         effMC = self.getTriggerEfficiencyMC( pt, eta, phi, dm )
         if effMC < 1e-5 :
-            print "Eff MC is suspiciously low. Please contact Tau POG."
-            print " - %s Trigger SF for Tau ID: %s   WP: %s   pT: %f   eta: %s   phi: %f" % (self.trigger, self.wpType, self.tauWP, pt, eta, phi)
-            print " - MC Efficiency = %f" % effMC
+            print("Eff MC is suspiciously low. Please contact Tau POG.")
+            print(" - %s Trigger SF for Tau ID: %s   WP: %s   pT: %f   eta: %s   phi: %f"%(self.trigger,self.wpType,self.tauWP,pt,eta,phi))
+            print(" - MC Efficiency = %f"%effMC)
             return 0.0
 
         if(self.year == 2016):
@@ -204,7 +204,7 @@ class TauTriggerSFTool :
                 if(effMC!=0): sf = effData / effMC
                 else:
                     sf = 0
-                    print "The efficiency is zero in either Data or MC histogram, so SF is set to zero"
+                    print("The efficiency is zero in either Data or MC histogram, so SF is set to zero")
             else:
                 sf = self.getBinnedScaleFactor(pt, dm, self.binnedSFMap[ dm])
 
@@ -212,7 +212,7 @@ class TauTriggerSFTool :
             if(effData!=0 and effMC!=0): sf = effData / effMC
             else:
                 sf = 0
-                print "The efficiency is zero in either Data or MC histogram, so SF is set to zero"
+                print("The efficiency is zero in either Data or MC histogram, so SF is set to zero")
 
         return sf
 

--- a/python/postprocessing/modules/common/tauCorrProducer.py
+++ b/python/postprocessing/modules/common/tauCorrProducer.py
@@ -6,7 +6,7 @@ from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
 from PhysicsTools.NanoAODTools.postprocessing.helpers.TauIDSFTool import TauIDSFTool, TauESTool, TauFESTool
 from PhysicsTools.NanoAODTools.postprocessing.tools import ensureTFile, extractTH1
 ROOT.PyConfig.IgnoreCommandLineOptions = True
-datapath = os.path.join(os.environ['CMSSW_BASE'],"src/PhysicsTools/NanoAODTools/python/postprocessing/data/tau")
+datapath = os.path.join(os.environ.get('CMSSW_BASE','CMSSW_BASE'),"src/PhysicsTools/NanoAODTools/python/postprocessing/data/tau")
 
 
 class TauCorrectionsProducer(Module):
@@ -15,7 +15,7 @@ class TauCorrectionsProducer(Module):
                              antiEleID='DeepTau2017v2p1VSe',   antiEleWPs=['VVLoose','Tight'],
                              antiMuID='DeepTau2017v2p1VSmu',   antiMuWPs=['VLoose','Tight'],
                              antiJetPerDM=False, sys=True,
-                             tes=True, fes=True, tesSys=True, verbose=False):
+                             tes=True, fes=True, tesSys=True, path=datapath, verbose=False):
         """Choose the IDs and WPs for SFs. For available tau IDs, WPs and corrections, check
         https://cms-nanoaod-integration.web.cern.ch/integration/master-102X/mc102X_doc.html#Tau"""
         
@@ -29,17 +29,17 @@ class TauCorrectionsProducer(Module):
         antiMuSFs  = [ ]
         if antiJetID:
           for wp in antiJetWPs:
-            antiJetSFs.append(TauIDSFTool(year,antiJetID,wp,dm=antiJetPerDM,path=datapath,verbose=verbose))
+            antiJetSFs.append(TauIDSFTool(year,antiJetID,wp,dm=antiJetPerDM,path=path,verbose=verbose))
         if antiEleID:
           for wp in antiEleWPs:
-            antiEleSFs.append(TauIDSFTool(year,antiEleID,wp,path=datapath,verbose=verbose))
+            antiEleSFs.append(TauIDSFTool(year,antiEleID,wp,path=path,verbose=verbose))
         if antiMuID:
           for wp in antiMuWPs:
-            antiMuSFs.append(TauIDSFTool(year,antiMuID,wp,path=datapath,verbose=verbose))
+            antiMuSFs.append(TauIDSFTool(year,antiMuID,wp,path=path,verbose=verbose))
         
         # TAU ENERGY SCALE
-        testool = TauESTool(year)  if tes else None
-        festool = TauFESTool(year) if fes else None
+        testool = TauESTool(year,path=path)  if tes else None
+        festool = TauFESTool(year,path=path) if fes else None
         
         self.antiJetID  = antiJetID   # name of the anti-jet discriminator
         self.antiJetSFs = antiJetSFs  # tool for the anti-jet discriminator SF
@@ -184,16 +184,16 @@ class TauCorrectionsProducer(Module):
         
         # FILL BRANCHES
         if self.doSys:
-          for key, toolSFs in tau_sfs.iteritems():
-            for tool, sfs in toolSFs.iteritems():
+          for key, toolSFs in tau_sfs.items():
+            for tool, sfs in toolSFs.items():
               #for tau, sfdown, sf, sfup in zip(taus,sfs[0],sfs[1],sfs[2]):
               #  if tau.genPartFlav>0: print ">>> %-38s %3d %5d %6.2f %6.2f %6.2f +%6.2f -%6.2f"%(tool.branchname,tau.genPartFlav,tau.decayMode,tau.pt,tau.eta,sf,sfup,sfdown)
               self.out.fillBranch(tool.branchname+'Down',sfs[0])
               self.out.fillBranch(tool.branchname,       sfs[1])
               self.out.fillBranch(tool.branchname+'Up',  sfs[2])
         else:
-          for key, toolSFs in tau_sfs.iteritems():
-            for tool, sfs in toolSFs.iteritems():
+          for key, toolSFs in tau_sfs.items():
+            for tool, sfs in toolSFs.items():
               self.out.fillBranch(tool.branchname,sfs)
         if self.doTES:
           self.out.fillBranch("Tau_pt_corr",         taus_pt_corr)

--- a/python/postprocessing/tools.py
+++ b/python/postprocessing/tools.py
@@ -83,7 +83,7 @@ def ensureTFile(filename,option='READ',verbose=False):
   if not os.path.isfile(filename):
     raise IOError("File in path '%s' does not exist!"%(filename))
   if verbose:
-    print "Opening '%s'..."%(filename)
+    print("Opening '%s'..."%(filename))
   file = ROOT.TFile.Open(filename,option)
   if not file or file.IsZombie():
     raise IOError("Could not open file by name '%s'"%(filename))


### PR DESCRIPTION
This makes the tau tools compatible with python3 and non-CMSSW standalone use as per request https://github.com/cms-nanoAOD/nanoAOD-tools/pull/258#issuecomment-773411712. Tested with both python 2.7 and 3.6 (via `source /cvmfs/sft.cern.ch/lcg/views/LCG_96python3/x86_64-centos7-gcc8-opt/setup.sh`) User can set the path to the data files, which otherwise assumes a `CMSSW_BASE` environmental variable.