### PR TITLE
Fix firstEntry bug

### DIFF
--- a/python/postprocessing/framework/output.py
+++ b/python/postprocessing/framework/output.py
@@ -173,7 +173,7 @@ class FullOutput(OutputTree):
         if self.outputbranchSelection:
             self.outputbranchSelection.selectBranches(self._tree)
         self._tree = self.tree().CopyTree('1', "",
-                                          self.maxEntries if self.maxEntries else ROOT.TVirtualTreePlayer.kMaxEntries, self.firstEntry)
+                                          self.maxEntries if self.maxEntries else ROOT.TVirtualTreePlayer.kMaxEntries, 0)
 
         OutputTree.write(self)
         for t in self._otherTrees.values():


### PR DESCRIPTION
The tree is already filtered just before writing, so `firstEntry>0` in https://github.com/cms-nanoAOD/nanoAOD-tools/blob/25a793ec55b30fe7107af263c4523f20ff1a5fbd/python/postprocessing/framework/output.py#L175-L176 causes a loss of events. See https://github.com/cms-nanoAOD/nanoAOD-tools/issues/269.