### PR TITLE
Fix firstEntry bug for fullClone

### DIFF
--- a/python/postprocessing/framework/postprocessor.py
+++ b/python/postprocessing/framework/postprocessor.py
@@ -208,6 +208,7 @@ class PostProcessor:
                 if self.friend:
                     outTree = FriendOutput(inFile, inTree, outFile)
                 else:
+                    firstEntry = 0 if fullClone and elist else self.firstEntry
                     outTree = FullOutput(
                         inFile,
                         inTree,
@@ -216,7 +217,7 @@ class PostProcessor:
                         outputbranchSelection=self.outputbranchsel,
                         fullClone=fullClone,
                         maxEntries=self.maxEntries,
-                        firstEntry=self.firstEntry,
+                        firstEntry=firstEntry,
                         jsonFilter=jsonFilter,
                         provenance=self.provenance)
             else:


### PR DESCRIPTION
This is a solution to Issue https://github.com/cms-nanoAOD/nanoAOD-tools/issues/274, which reported that in the special case where the user passes no modules (such that `fullClone==True`), but passes a JSON file via the `jsonInput` option, and/or a cut via `cut`, there seems to a loss of events, because the entry index is not properly shifted when an event list (vector `elist`) is created. @gouskos

I checked different settings. This is before fixing the bug:
```
firstEntry maxEntry           cut     json    ntot   full event range   entries 0-99       entries 100-199  
         0      200          None    False     200   67064147-68648544  67082251-68648544  67064147-68609297
         0      200          None    False     200   67064147-68648544  67082251-68648544  67064147-68609297
         0      200          None     True     200   67064147-68648544  67082251-68648544  67064147-68609297
         0      200  'Muon_pt>25'    False     148   67064147-68648544
         0      200  'Muon_pt>25'     True     148   67064147-68648544
         0      100          None    False     100   67082251-68648544
         0      100          None     True     100   67082251-68648544
         0      100  'Muon_pt>25'    False      78   67107368-68648544
         0      100  'Muon_pt>25'     True      78   67107368-68648544
        50      100          None    False     100   67064147-68648544
        50      100          None     True      50   67064147-68601708
        50      100  'Muon_pt>25'    False      20   67158063-68601708
        50      100  'Muon_pt>25'     True      20   67158063-68601708
       100      100          None    False     100   67064147-68609297
       100      100          None     True       0   -
       100      100  'Muon_pt>25'    False       0   -
       100      100  'Muon_pt>25'     True       0   -
```
You can see that in the case that `firstEntry` is larger than 0, there will be fewer events `ntot` than expected. I also checked that there is no overlap by comparing event ranges for different entry ranges, but it's a bit hard because the event numbers are not ordered.

This is after fixing the bug:
```
firstEntry maxEntry           cut     json    ntot   full event range   entries 0-99       entries 100-199  
         0      200          None    False     200   67064147-68648544  67082251-68648544  67064147-68609297
         0      200          None    False     200   67064147-68648544  67082251-68648544  67064147-68609297
         0      200          None     True     200   67064147-68648544  67082251-68648544  67064147-68609297
         0      200  'Muon_pt>25'    False     148   67064147-68648544
         0      200  'Muon_pt>25'     True     148   67064147-68648544
         0      100          None    False     100   67082251-68648544
         0      100          None     True     100   67082251-68648544
         0      100  'Muon_pt>25'    False      78   67107368-68648544
         0      100  'Muon_pt>25'     True      78   67107368-68648544
        50      100          None    False     100   67064147-68648544
        50      100          None     True     100   67064147-68648544
        50      100  'Muon_pt>25'    False      70   67064147-68648544
        50      100  'Muon_pt>25'     True      70   67064147-68648544
       100      100          None    False     100   67064147-68609297
       100      100          None     True     100   67064147-68609297
       100      100  'Muon_pt>25'    False      70   67064147-68601708
       100      100  'Muon_pt>25'     True      70   67064147-68601708
```
If you would like to check for yourself:
```python
from __future__ import print_function
import os, sys
from PhysicsTools.NanoAODTools.postprocessing.framework.postprocessor import PostProcessor
from ROOT import TFile

goodevts = { # reduced JSON to test behavior
  # /afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/Final/Cert_271036-284044_13TeV_PromptReco_Collisions16_JSON.txt
  "278803": [[1, 87], [91, 133], [135, 297], [299, 323]],
  "278804": [[1, 4]],
  "278805": [[3, 26], [30, 167], [170, 193], [196, 280], [283, 284], [288, 288]],
  "278808": [[1, 445], [447, 462], [464, 1793]],
}
cut = "Muon_pt>25" #"nMuon>0"
tag = ""
configs = [
  # https://github.com/cms-nanoAOD/nanoAOD-tools/blob/master/python/postprocessing/framework/postprocessor.py#L16-L24
  (  0,200,None,    None,tag),
  (  0,200,None,    None,tag),
  (  0,200,None,goodevts,tag),
  (  0,200, cut,    None,tag),
  (  0,200, cut,goodevts,tag),
  (  0,100,None,    None,tag),
  (  0,100,None,goodevts,tag),
  (  0,100, cut,    None,tag),
  (  0,100, cut,goodevts,tag),
  ( 50,100,None,    None,tag),
  ( 50,100,None,goodevts,tag),
  ( 50,100, cut,    None,tag),
  ( 50,100, cut,goodevts,tag),
  (100,100,None,    None,tag),
  (100,100,None,goodevts,tag),
  (100,100, cut,    None,tag),
  (100,100, cut,goodevts,tag),
]
branchsel = None
modules   = [ ]
infiles = [
  # Run2016F: 277772-278808
  # dasgoclient --query="/SingleMuon/Run2016F-UL2016_MiniAODv1_NanoAODv2-v4/NANOAOD file"
  # xrdcp root://xrootd-cms.infn.it//store/data/Run2016F/SingleMuon/NANOAOD/UL2016_MiniAODv1_NanoAODv2-v4/230000/EB3E1D56-2A5B-0640-9FC7-AED436ECCDB8.root ./
  # Events->Scan("run:luminosityBlock:event")
  "EB3E1D56-2A5B-0640-9FC7-AED436ECCDB8.root",
]

rows = [ ]
print()
for firstEvt, maxEvts, cut, json, extratag in configs:
  #tag = "_old_%s-%s"%(firstEvt,maxEvts)
  tag = "_new_%s-%s"%(firstEvt,maxEvts)
  if cut:
    tag += "_"+cut.replace('>',"gt").replace('<',"lt").replace(' ',"").replace('&&',"-")
  if json:
    tag += "_json"
  tag += extratag
  print(">>> %-10s = %r"%('postfix', tag))
  print(">>> %-10s = %s"%('modules', modules))
  print(">>> %-10s = %s"%('firstEvt',firstEvt))
  print(">>> %-10s = %s"%('maxEvts', maxEvts))
  print(">>> %-10s = %s"%('infiles', infiles))
  print(">>> %-10s = %r"%('json',    json))
  p = PostProcessor(".", infiles, postfix=tag, modules=modules,
                    cut=cut, jsonInput=json, firstEntry=firstEvt, maxEntries=maxEvts,
                    branchsel=branchsel, outputbranchsel=branchsel)
  p.run()
  fname = infiles[0].replace(".root",tag+".root")
  file = TFile.Open(fname)
  tree = file.Get("Events")
  ntot = tree.Draw("event","",'gOff')
  evec = tree.GetV1() # not sorted
  evts = [int(evec[i]) for i in range(ntot)]
  if ntot>0:
    erange = "%8d-%8d"%(min(evts),max(evts))
  else:
    erange = "-"
  if ntot==200: # check event range for first and second 100 entries
    erange += "  %8d-%8d"%(min(evts[  0:100]),max(evts[  0:100]))
    erange += "  %8d-%8d"%(min(evts[100:200]),max(evts[100:200]))
  row = ">>> %10s %8s %13r %8s %7s   %s"%(firstEvt,maxEvts,cut,bool(json),ntot,erange)
  rows.append(row)
  print()
  
print(">>> %10s %8s %13s %8s %7s   %-17s  %-17s  %-17s"%(
      "firstEntry","maxEntry","cut","json","ntot","full event range","entries 0-99","entries 100-199"))
for row in rows:
  print(row)
print()
```