### PR TITLE
Undo JEC for subjets in FatJet

### DIFF
--- a/python/postprocessing/modules/jme/fatJetUncertainties.py
+++ b/python/postprocessing/modules/jme/fatJetUncertainties.py
@@ -547,8 +547,8 @@ class fatJetUncertaintiesProducer(Module):
                     genGroomedSubJets = None
                     genGroomedJet = None
                 if jet.subJetIdx1 >= 0 and jet.subJetIdx2 >= 0:
-                    groomedP4 = subJets[jet.subJetIdx1].p4() + subJets[
-                        jet.subJetIdx2].p4()  # check subjet jecs
+                    groomedP4 = (subJets[jet.subJetIdx1].p4() * (1. - subJets[jet.subJetIdx1].rawFactor))
+                        + (subJets[jet.subJetIdx2].p4() * (1. - subJets[jet.subJetIdx2].rawFactor))
                 else:
                     groomedP4 = None
 

--- a/python/postprocessing/modules/jme/fatJetUncertainties.py
+++ b/python/postprocessing/modules/jme/fatJetUncertainties.py
@@ -547,7 +547,7 @@ class fatJetUncertaintiesProducer(Module):
                     genGroomedSubJets = None
                     genGroomedJet = None
                 if jet.subJetIdx1 >= 0 and jet.subJetIdx2 >= 0:
-                    groomedP4 = (subJets[jet.subJetIdx1].p4() * (1. - subJets[jet.subJetIdx1].rawFactor))
+                    groomedP4 = (subJets[jet.subJetIdx1].p4() * (1. - subJets[jet.subJetIdx1].rawFactor)) \
                         + (subJets[jet.subJetIdx2].p4() * (1. - subJets[jet.subJetIdx2].rawFactor))
                 else:
                     groomedP4 = None


### PR DESCRIPTION
This PR is to address issue #280. The subjets' p4 should now have the raw (i.e no JEC applied on them) p4 and the raw softdrop mass can be correctly calculated. 