### PR TITLE
Add UL case for JMS&JMR SD corr in fatJetUncertainties

### DIFF
--- a/python/postprocessing/modules/jme/fatJetUncertainties.py
+++ b/python/postprocessing/modules/jme/fatJetUncertainties.py
@@ -627,17 +627,18 @@ class fatJetUncertaintiesProducer(Module):
                         jet_msdcorr_raw)
 
                     # Also evaluated JMS&JMR SD corr in tau21DDT region: https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetWtagging#tau21DDT_0_43
-                    if self.era in ["2016"]:
+                    # UL recommendations not yet available, use same factors in both cases
+                    if self.era in ["2016", "UL2016", "UL2016_preVFP"]:
                         jmstau21DDTNomVal = 1.014
                         jmstau21DDTDownVal = 1.007
                         jmstau21DDTUpVal = 1.021
                         self.jetSmearer.jmr_vals = [1.086, 1.176, 0.996]
-                    elif self.era in ["2017"]:
+                    elif self.era in ["2017", "UL2017"]:
                         jmstau21DDTNomVal = 0.983
                         jmstau21DDTDownVal = 0.976
                         jmstau21DDTUpVal = 0.99
                         self.jetSmearer.jmr_vals = [1.080, 1.161, 0.999]
-                    elif self.era in ["2018"]:
+                    elif self.era in ["2018", "UL2018"]:
                         jmstau21DDTNomVal = 1.000  # tau21DDT < 0.43 WP
                         jmstau21DDTDownVal = 0.990
                         jmstau21DDTUpVal = 1.010

--- a/python/postprocessing/modules/jme/fatJetUncertainties.py
+++ b/python/postprocessing/modules/jme/fatJetUncertainties.py
@@ -628,17 +628,32 @@ class fatJetUncertaintiesProducer(Module):
 
                     # Also evaluated JMS&JMR SD corr in tau21DDT region: https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetWtagging#tau21DDT_0_43
                     # UL recommendations not yet available, use same factors in both cases
-                    if self.era in ["2016", "UL2016", "UL2016_preVFP"]:
+                    if self.era in ["2016"]:
                         jmstau21DDTNomVal = 1.014
                         jmstau21DDTDownVal = 1.007
                         jmstau21DDTUpVal = 1.021
                         self.jetSmearer.jmr_vals = [1.086, 1.176, 0.996]
-                    elif self.era in ["2017", "UL2017"]:
+                    elif self.era in ["2017"]:
                         jmstau21DDTNomVal = 0.983
                         jmstau21DDTDownVal = 0.976
                         jmstau21DDTUpVal = 0.99
                         self.jetSmearer.jmr_vals = [1.080, 1.161, 0.999]
-                    elif self.era in ["2018", "UL2018"]:
+                    elif self.era in ["2018"]:
+                        jmstau21DDTNomVal = 1.000  # tau21DDT < 0.43 WP
+                        jmstau21DDTDownVal = 0.990
+                        jmstau21DDTUpVal = 1.010
+                        self.jetSmearer.jmr_vals = [1.124, 1.208, 1.040]
+                    elif self.era in ["UL2016", "UL2016_preVFP"]:
+                        jmstau21DDTNomVal = 1.014
+                        jmstau21DDTDownVal = 1.007
+                        jmstau21DDTUpVal = 1.021
+                        self.jetSmearer.jmr_vals = [1.086, 1.176, 0.996]
+                    elif self.era in ["UL2017"]:
+                        jmstau21DDTNomVal = 0.983
+                        jmstau21DDTDownVal = 0.976
+                        jmstau21DDTUpVal = 0.99
+                        self.jetSmearer.jmr_vals = [1.080, 1.161, 0.999]
+                    elif self.era in ["UL2018"]:
                         jmstau21DDTNomVal = 1.000  # tau21DDT < 0.43 WP
                         jmstau21DDTDownVal = 0.990
                         jmstau21DDTUpVal = 1.010


### PR DESCRIPTION
When using `fatJetUncertaintiesProducer` with UL era (e.g. UL2018) the code crashes  in [this line](https://github.com/cms-nanoAOD/nanoAOD-tools/blob/e963c7080606607777b083f59d752fe67b766265/python/postprocessing/modules/jme/fatJetUncertainties.py#L654), since `era` string doesn't cover UL cases in the [previous if statement](https://github.com/cms-nanoAOD/nanoAOD-tools/blob/e963c7080606607777b083f59d752fe67b766265/python/postprocessing/modules/jme/fatJetUncertainties.py#L630). With this simple fix the code works. Please note, that the corrections in [JetWtagging twiki](https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetWtagging) doesn't have separate factors for UL.

This issue was reported here: https://github.com/cms-nanoAOD/nanoAOD-tools/issues/285

@lathomas, @kirschen, @gouskos, @nowaythatsok