### PR TITLE
Fixed null pointer conversion error for newer versions of ROOT

### DIFF
--- a/python/postprocessing/framework/postprocessor.py
+++ b/python/postprocessing/framework/postprocessor.py
@@ -193,7 +193,10 @@ class PostProcessor:
                     inTree.SetEntryList(elist)
             else:
                 # initialize reader
-                inTree = InputTree(inTree, elist)
+                if elist:
+                    inTree = InputTree(inTree, elist)
+                else:
+                    inTree = InputTree(inTree)
 
             # prepare output file
             if not self.noOut:

--- a/python/postprocessing/framework/treeReaderArrayTools.py
+++ b/python/postprocessing/framework/treeReaderArrayTools.py
@@ -3,7 +3,7 @@ import ROOT
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 
 
-def InputTree(tree, entrylist=None):
+def InputTree(tree, entrylist=ROOT.MakeNullPointer(ROOT.TEntryList)):
     """add to the PyROOT wrapper of a TTree a TTreeReader and methods readBranch, arrayReader, valueReader"""
     if hasattr(tree, '_ttreereader'):
         return tree  # don't initialize twice
@@ -116,7 +116,7 @@ def _makeValueReader(tree, typ, nam):
 
 
 def _remakeAllReaders(tree):
-    _ttreereader = ROOT.TTreeReader(tree, getattr(tree, '_entrylist', None))
+    _ttreereader = ROOT.TTreeReader(tree, getattr(tree, '_entrylist', ROOT.MakeNullPointer(ROOT.TEntryList)))
     _ttreereader._isClean = True
     _ttrvs = {}
     for k in tree._ttrvs.keys():


### PR DESCRIPTION
As mentioned in [this](https://github.com/cms-nanoAOD/nanoAOD-tools/issues/277) issue, a conversion error is thrown when running the postprocessor with newer versions of ROOT. In particular, it is complaining about the TEntryList being supplied to the constructor. I believe this is because `entrylist` is NoneType by default, rather than a null pointer. By replacing this default value with `ROOT.MakeNullPointer(ROOT.TEntryList)`, the `TTreeReader` constructor instead receives a nullpointer as it expects. I tested this simple fix using CMSSW v12.1.0 (pre, with ROOT v6.24) and CMSSW v10.6.25. I used a custom module and skimmed some custom MC signal samples for the test.