### PR TITLE
merge THnSparse object in haddnano

### DIFF
--- a/scripts/haddnano.py
+++ b/scripts/haddnano.py
@@ -101,5 +101,8 @@ for e in fileHandles[0].GetListOfKeys():
             if st.GetString() != obj.GetString():
                 print("Strings are not matching")
         obj.Write()
+    elif obj.IsA().InheritsFrom(ROOT.THnSparse.Class()) :
+        obj.Merge(inputs)
+        obj.Write()
     else:
         print("Cannot handle " + str(obj.IsA().GetName()))


### PR DESCRIPTION
A THnSparse object is needed to save the models in pMSSM. For other analysis using nanoAOD tools within SUSY that are involved in the pMSSM paper this will be needed.