### PR TITLE
Fix crash when no entries are pre-selected in an event

### DIFF
--- a/python/postprocessing/framework/postprocessor.py
+++ b/python/postprocessing/framework/postprocessor.py
@@ -175,6 +175,10 @@ class PostProcessor:
                     if toBeDeleted:
                         os.unlink(ftoread)
                 continue
+            elif elist and elist.GetN() == 0:
+                    # stop processing if no entries got pre-selected
+                    print('Pre-select 0 entries out of %s (0.00%%)' % (nEntries))
+                    continue
             else:
                 print('Pre-select %d entries out of %s (%.2f%%)' % (elist.GetN() if elist else nEntries, nEntries, (elist.GetN() if elist else nEntries) / (0.01 * nEntries) if nEntries else 0))
                 inAddFiles = []


### PR DESCRIPTION
NanoAODTools crashes if no entries in an input file got pre-selected due to adding a `cut` and/or `jsonInput` in `postprocessor.py`. This PR fixes that by not processing the input file if 0 entries got pre-selected.

The error message when this crash occurs can be seen below:

```== CMSSW: Pre-select 0 entries out of 285637 (0.00%)
== CMSSW: nanoAODv5 or higher: True
== CMSSW: Traceback (most recent call last):
== CMSSW:   File "/srv/crabPostProc.py", line 131, in <module>
== CMSSW:     p.run()
== CMSSW:   File "/srv/CMSSW_12_3_0_pre2/python/PhysicsTools/NanoAODTools/postprocessing/framework/postprocessor.py", line 236, in run
== CMSSW:     (nall, npass, timeLoop) = eventLoop(
== CMSSW:   File "/srv/CMSSW_12_3_0_pre2/python/PhysicsTools/NanoAODTools/postprocessing/framework/eventloop.py", line 82, in eventLoop
== CMSSW:     ret = m.analyze(e)
== CMSSW:   File "/srv/CMSSW_12_3_0_pre2/python/PhysicsTools/NanoAODTools/postprocessing/modules/jme/jetmetUncertainties.py", line 334, in analyze
== CMSSW:     jets = Collection(event, self.jetBranchName)
== CMSSW:   File "/srv/CMSSW_12_3_0_pre2/python/PhysicsTools/NanoAODTools/postprocessing/framework/datamodel.py", line 116, in __init__
== CMSSW:     self._len = getattr(event, "n" + prefix)
== CMSSW:   File "/srv/CMSSW_12_3_0_pre2/python/PhysicsTools/NanoAODTools/postprocessing/framework/datamodel.py", line 18, in __getattr__
== CMSSW:     return self._tree.readBranch(name)
== CMSSW:   File "/srv/CMSSW_12_3_0_pre2/python/PhysicsTools/NanoAODTools/postprocessing/framework/treeReaderArrayTools.py", line 89, in readBranch
== CMSSW:     ret = _vr.Get()[0]
== CMSSW: ReferenceError: attempt to access a null-pointer
```