### PR TITLE
Fix crash when no entries are pre-selected in a crab job

### DIFF
--- a/python/postprocessing/framework/postprocessor.py
+++ b/python/postprocessing/framework/postprocessor.py
@@ -262,7 +262,7 @@ class PostProcessor:
 
         print("Total time %.1f sec. to process %i events. Rate = %.1f Hz." % ((time.time() - t0), totEntriesRead, totEntriesRead / (time.time() - t0)))
 
-        if self.haddFileName:
+        if self.haddFileName and outFileNames:
             haddnano = "./haddnano.py" if os.path.isfile(
                 "./haddnano.py") else "haddnano.py"
             os.system("%s %s %s" %

--- a/python/postprocessing/framework/postprocessor.py
+++ b/python/postprocessing/framework/postprocessor.py
@@ -175,10 +175,6 @@ class PostProcessor:
                     if toBeDeleted:
                         os.unlink(ftoread)
                 continue
-            elif elist and elist.GetN() == 0:
-                    # stop processing if no entries got pre-selected
-                    print('Pre-select 0 entries out of %s (0.00%%)' % (nEntries))
-                    continue
             else:
                 print('Pre-select %d entries out of %s (%.2f%%)' % (elist.GetN() if elist else nEntries, nEntries, (elist.GetN() if elist else nEntries) / (0.01 * nEntries) if nEntries else 0))
                 inAddFiles = []
@@ -234,7 +230,7 @@ class PostProcessor:
                     self.branchsel.selectBranches(inTree)
 
             # process events, if needed
-            if not fullClone:
+            if not fullClone and not (elist and elist.GetN() == 0):
                 eventRange = range(self.firstEntry, self.firstEntry +
                                     nEntries) if nEntries > 0 and not elist else None
                 (nall, npass, timeLoop) = eventLoop(
@@ -262,7 +258,7 @@ class PostProcessor:
 
         print("Total time %.1f sec. to process %i events. Rate = %.1f Hz." % ((time.time() - t0), totEntriesRead, totEntriesRead / (time.time() - t0)))
 
-        if self.haddFileName and outFileNames:
+        if self.haddFileName:
             haddnano = "./haddnano.py" if os.path.isfile(
                 "./haddnano.py") else "haddnano.py"
             os.system("%s %s %s" %


### PR DESCRIPTION
TL;DR: Quick fix to avoid crashes when no events in a job gets pre-selected when running code via e.g. crab.

Long version: in a previous PR I solved an issue with NanoAODTools crashing if no events got pre-selected in one of the input files (https://github.com/cms-nanoAOD/nanoAOD-tools/pull/303). However, in that solution we stopped processing the event straight after the pre-selection, thus not adding anything to the job report or creating any output files. This was fine for running interactively, but caused issues if you submitted a job to e.g. crab if no events in the job got pre-selected. Then it tried to run the haddnano.py script merging the non-existent output files and crashing, and the crab jobs were also looking for the outputs and crashed when they were not found. In this PR I have moved the pre-selection check to the event loop instead, so it still creates output files (albeit empty) even if no events got pre-selected to avoid any issues with crab. 