### PR TITLE
Protect against files with zero pre-selected events

### DIFF
--- a/python/postprocessing/framework/postprocessor.py
+++ b/python/postprocessing/framework/postprocessor.py
@@ -238,7 +238,7 @@ class PostProcessor:
                     eventRange=eventRange, maxEvents=self.maxEntries
                 )
                 print('Processed %d preselected entries from %s (%s entries). Finally selected %d entries' % (nall, fname, nEntries, npass))
-            elif outTree!=None:
+            elif outTree is not None:
                 nall = nEntries
                 print('Selected %d / %d entries from %s (%.2f%%)' % (outTree.tree().GetEntries(), nall, fname, outTree.tree().GetEntries() / (0.01 * nall) if nall else 0))
 

--- a/python/postprocessing/framework/postprocessor.py
+++ b/python/postprocessing/framework/postprocessor.py
@@ -238,7 +238,7 @@ class PostProcessor:
                     eventRange=eventRange, maxEvents=self.maxEntries
                 )
                 print('Processed %d preselected entries from %s (%s entries). Finally selected %d entries' % (nall, fname, nEntries, npass))
-            else:
+            elif outTree!=None:
                 nall = nEntries
                 print('Selected %d / %d entries from %s (%.2f%%)' % (outTree.tree().GetEntries(), nall, fname, outTree.tree().GetEntries() / (0.01 * nall) if nall else 0))
 

--- a/scripts/haddnano.py
+++ b/scripts/haddnano.py
@@ -15,7 +15,7 @@ def zeroFill(tree, brName, brObj, allowNonBool=False):
         'u4', 'i'), 'Long64_t': ('i8', 'L'), 'Double_t': ('f8', 'D')}
     brType = brObj.GetLeaf(brName).GetTypeName()
     if (not allowNonBool) and (brType != "Bool_t"):
-        print(("Did not expect to back fill non-boolean branches", tree, brName, brObj.GetLeaf(br).GetTypeName()))
+        print(("Did not expect to back fill non-boolean branches ", tree, brName, brObj.GetLeaf(br).GetTypeName()))
     else:
         if brType not in branch_type_dict:
             raise RuntimeError('Impossible to backfill branch of type %s' % brType)
@@ -32,7 +32,7 @@ def zeroFill(tree, brName, brObj, allowNonBool=False):
 fileHandles = []
 goFast = True
 for fn in files:
-    print("Adding file" + str(fn))
+    print("Adding file " + str(fn))
     fileHandles.append(ROOT.TFile.Open(fn))
     if fileHandles[-1].GetCompressionSettings() != fileHandles[0].GetCompressionSettings():
         goFast = False
@@ -61,7 +61,7 @@ for e in fileHandles[0].GetListOfKeys():
                                  for x in otherObj.GetListOfBranches()])
             missingBranches = list(branchNames - otherBranches)
             additionalBranches = list(otherBranches - branchNames)
-            print("missing: " + str(missingBranches) + "\n Additional:" + str(additionalBranches))
+            print("missing: " + str(missingBranches) + "\n Additional: " + str(additionalBranches))
             for br in missingBranches:
                 # fill "Other"
                 zeroFill(otherObj, br, obj.GetListOfBranches().FindObject(br))
@@ -76,7 +76,7 @@ for e in fileHandles[0].GetListOfKeys():
                                  for x in otherObj.GetListOfBranches()])
             missingBranches = list(branchNames - otherBranches)
             additionalBranches = list(otherBranches - branchNames)
-            print("missing: " + str(missingBranches) + "\n Additional:" + str(additionalBranches))
+            print("missing: " + str(missingBranches) + "\n Additional: " + str(additionalBranches))
             for br in missingBranches:
                 # fill "Other"
                 zeroFill(otherObj, br, obj.GetListOfBranches(


### PR DESCRIPTION
This PR adds a simple if-statement to protect to the case were zero events were preselected.

I ran into this error for several data files for which no events were in the good event list of the golden JSON, leading to failing jobs (`self.noOut` set to `True`). Otherwise I have to manually filter the input file list for the jobs.