### PR TITLE
Fix ord bug in prefetch for python2-3 compatibility

### DIFF
--- a/python/postprocessing/framework/postprocessor.py
+++ b/python/postprocessing/framework/postprocessor.py
@@ -65,7 +65,7 @@ class PostProcessor:
             return fname, False
         rndchars = "".join([hex(i)[2:] for i in bytearray(os.urandom(8))]) \
             if not self.longTermCache else "long_cache-id%d-%s" \
-            % (os.getuid(), hashlib.sha1(fname).hexdigest())
+            % (os.getuid(), hashlib.sha1(fname.encode('utf-8')).hexdigest())
         localfile = "%s/%s-%s.root" \
             % (tmpdir, os.path.basename(fname).replace(".root", ""), rndchars)
         if self.longTermCache and os.path.exists(localfile):

--- a/python/postprocessing/framework/postprocessor.py
+++ b/python/postprocessing/framework/postprocessor.py
@@ -63,8 +63,8 @@ class PostProcessor:
         tmpdir = os.environ['TMPDIR'] if 'TMPDIR' in os.environ else "/tmp"
         if not fname.startswith("root://"):
             return fname, False
-        rndchars = "".join([hex(ord(i))[2:] for i in os.urandom(
-            8)]) if not self.longTermCache else "long_cache-id%d-%s" \
+        rndchars = "".join([hex(i)[2:] for i in bytearray(os.urandom(8))]) \
+            if not self.longTermCache else "long_cache-id%d-%s" \
             % (os.getuid(), hashlib.sha1(fname).hexdigest())
         localfile = "%s/%s-%s.root" \
             % (tmpdir, os.path.basename(fname).replace(".root", ""), rndchars)


### PR DESCRIPTION
# BUG 1: `ord`
This bug appears when using the prefetch option in python3:
```
$ python2 -c "import os; print(type(os.urandom(8))); print(ord(os.urandom(8)[1]))"
<type 'str'>
106

$ python3 -c "import os; print(type(os.urandom(8))); print(ord(os.urandom(8)[1]))"
<class 'bytes'>
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: ord() expected string of length 1, but int found
```
For python3, `ord` should be removed for this to work.

The best solution for keeping compatibility between both python2 and python3 I could immediately find is using `bytearray`
```
$ python2 -c 'import os; a=os.urandom(8); print(", ".join([hex(ord(i))[2:] for i in a])); print(", ".join([hex(i)[2:] for i in bytearray(a)]))'
38, 6e, b3, d2, fb, 70, 4d, e6
38, 6e, b3, d2, fb, 70, 4d, e6

$ python3 -c 'import os; a=os.urandom(8); print(", ".join([hex(i)[2:] for i in a])); print(", ".join([hex(i)[2:] for i in bytearray(a)]))'
5d, 42, 7, 61, 5a, 16, bd, 56
5d, 42, 7, 61, 5a, 16, bd, 56
```

# BUG 2: Encoding for hashing
This bug appears when using the `prefetch` _and_ the `longTermCache`  option in python3:
```
$ python2 -c 'import os, hashlib; print(os.getuid()); print(hashlib.sha1("fname").hexdigest())'
628
6dbff8baa2167c52eeb72d407642eb430ca0b271

$ python3 -c 'import os, hashlib; print(os.getuid()); print(hashlib.sha1("fname").hexdigest())'
628
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: Unicode-objects must be encoded before hashing
```
Simplest fix that works for both python2 and python3 is to add `.encode("utf-8")`:
```
$ python2 -c 'import os, hashlib; print(os.getuid()); print(hashlib.sha1("fname".encode("utf-8")).hexdigest())'
628
6dbff8baa2167c52eeb72d407642eb430ca0b271

$ python3 -c 'import os, hashlib; print(os.getuid()); print(hashlib.sha1("fname".encode("utf-8")).hexdigest())'
628
6dbff8baa2167c52eeb72d407642eb430ca0b271
```